### PR TITLE
Laravel 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/notifications": "^5.3",
-        "illuminate/support": "^5.1|^5.2|^5.3",
-        "guzzlehttp/guzzle": "^5.3.3|^6.2.1",
+        "illuminate/notifications": "^5.3 || ^6.7",
+        "illuminate/support": "^5.1 || ^6.7",
+        "guzzlehttp/guzzle": "^5.3.3 || ^6.2.1",
         "guzzlehttp/psr7": "^1.4.1",
         "guzzlehttp/promises": "~1.0",
         "ramsey/uuid": "^3.7",
@@ -24,8 +24,8 @@
         "ext-simplexml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.4.3",
-        "mockery/mockery": "^0.9.5",
+        "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^8.0",
+        "mockery/mockery": "^0.9.5 || ^1.0",
         "ext-openssl": "*",
         "ext-dom": "*",
         "ext-pcntl": "*",
@@ -58,7 +58,7 @@
             "tests/Fixtures/Helpers.php"
         ]
     },
-    
+
     "scripts": {
         "test": "vendor/bin/phpunit"
     }


### PR DESCRIPTION
Simply adds new versions to composer.json for Laravel 6 support.

Composer only mentions double pipes. Also simplified the required versions because of semver rules with carets