### PR TITLE
Proposal: Remove UUID log

### DIFF
--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -3,7 +3,6 @@
 namespace Ringierimu\ServiceBusNotificationsChannel;
 
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Log;
 use Ramsey\Uuid\Uuid;
 use Ringierimu\ServiceBusNotificationsChannel\Exceptions\InvalidConfigException;
 use Throwable;

--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -240,11 +240,7 @@ class ServiceBusEvent
      */
     private function generateUUID(string $key): string
     {
-        $uuid = Uuid::uuid5(Uuid::NAMESPACE_DNS, 'php.net');
-
-        Log::info('Generating UUID', ['tag' => 'ServiceBus', 'id' => $uuid->toString(), 'key' => $key]);
-
-        return $uuid->toString();
+        return Uuid::uuid5(Uuid::NAMESPACE_DNS, 'php.net')->toString();
     }
 
     /**

--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -215,7 +215,7 @@ class ServiceBusEvent
      */
     protected function getVentureReference(): string
     {
-        return $this->ventureReference ?? $this->generateUUID('venture_reference');
+        return $this->ventureReference ?? $this->generateUUID();
     }
 
     /**
@@ -231,15 +231,13 @@ class ServiceBusEvent
     /**
      * Generates a v4 UUID.
      *
-     * @param string $key
-     *
      * @throws Throwable
      *
      * @return string
      */
-    private function generateUUID(string $key): string
+    private function generateUUID(): string
     {
-        return Uuid::uuid5(Uuid::NAMESPACE_DNS, 'php.net')->toString();
+        return Uuid::uuid4()->toString();
     }
 
     /**


### PR DESCRIPTION
This has logged that it's generated a UUID 9000 times in the last 4 hours. Is this used by anything?

Also, I don't think we should be using _php.net_ in that call; it should be a central RIMU hostname since this is a RIMU-scoped package, but I won't change that now because I'm not sure if it will clash with existing UUIDs out there. _Should_ be safe to change cos the events don't live long, but not my call...