### PR TITLE
Don't generate a new UUID every time the venture reference is asked for

### DIFF
--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -61,6 +61,7 @@ class ServiceBusEvent
             $this->ventureConfig[$name] = isset($ventureConfig[$name]) ? $ventureConfig[$name] : config($name);
         }
 
+        $this->createdAt = Carbon::now();
         $this->ventureReference = $this->generateUUID();
     }
 
@@ -243,7 +244,7 @@ class ServiceBusEvent
             'events'            => [$this->eventType],
             'venture_reference' => $this->ventureReference,
             'venture_config_id' => $this->ventureConfig['services.service_bus.venture_config_id'],
-            'created_at'        => $this->createdAt ? $this->createdAt->toIso8601String() : Carbon::now()->toIso8601String(),
+            'created_at'        => $this->createdAt->toIso8601String(),
             'culture'           => $this->getCulture(),
             'action_type'       => $this->actionType,
             'action_reference'  => $this->actionReference,

--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -2,7 +2,7 @@
 
 namespace Ringierimu\ServiceBusNotificationsChannel;
 
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use Ramsey\Uuid\Uuid;
 use Ringierimu\ServiceBusNotificationsChannel\Exceptions\InvalidConfigException;
 use Throwable;

--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -60,6 +60,8 @@ class ServiceBusEvent
         foreach ($ventureConfigVars as $name) {
             $this->ventureConfig[$name] = isset($ventureConfig[$name]) ? $ventureConfig[$name] : config($name);
         }
+
+        $this->ventureReference = $this->generateUUID();
     }
 
     /**
@@ -207,18 +209,6 @@ class ServiceBusEvent
     }
 
     /**
-     * Get the venture reference, will generate a UUID if not set on the event.
-     *
-     * @throws Throwable
-     *
-     * @return string
-     */
-    protected function getVentureReference(): string
-    {
-        return $this->ventureReference ?? $this->generateUUID();
-    }
-
-    /**
      * Gets the extra data to be sent as the payload param.
      *
      * @return array
@@ -251,7 +241,7 @@ class ServiceBusEvent
     {
         return [
             'events'            => [$this->eventType],
-            'venture_reference' => $this->getVentureReference(),
+            'venture_reference' => $this->ventureReference,
             'venture_config_id' => $this->ventureConfig['services.service_bus.venture_config_id'],
             'created_at'        => $this->createdAt ? $this->createdAt->toIso8601String() : Carbon::now()->toIso8601String(),
             'culture'           => $this->getCulture(),


### PR DESCRIPTION
Generate a default UUID which can be overridden by the caller. With current code if you call _getParams_ twice you'll get a different UUID.

Also, the same is being done for createdAt.