### PR TITLE
Revert change to Carbon class

### DIFF
--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -2,7 +2,7 @@
 
 namespace Ringierimu\ServiceBusNotificationsChannel;
 
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Ramsey\Uuid\Uuid;
 use Ringierimu\ServiceBusNotificationsChannel\Exceptions\InvalidConfigException;
 use Throwable;


### PR DESCRIPTION
I pulled the trigger a bit early here - changing the Carbon class back to what it was - it's causing type declaration issues downstream in the venture.