### PR TITLE
Fix debug log

### DIFF
--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -66,8 +66,7 @@ class ServiceBusChannel
         $params = $event->getParams();
 
         if ($this->ventureConfig['services.service_bus.enabled'] == false) {
-            Log::info('Service Bus disabled, event discarded', ['tag' => 'ServiceBus']);
-            Log::debug(print_r($params, true), ['tag' => 'ServiceBus']);
+            Log::info('Service Bus disabled, event discarded', ['tag' => 'ServiceBus', 'params' => $params]);
 
             return;
         }

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -66,7 +66,13 @@ class ServiceBusChannel
         $params = $event->getParams();
 
         if ($this->ventureConfig['services.service_bus.enabled'] == false) {
-            Log::info('Service Bus disabled, event discarded', ['tag' => 'ServiceBus', 'params' => $params]);
+            Log::info(
+                'Service Bus disabled, event discarded',
+                [
+                    'tag' => 'ServiceBus',
+                    'params' => $params,
+                ]
+            );
 
             return;
         }
@@ -88,10 +94,21 @@ class ServiceBusChannel
                 ]
             );
 
-            Log::info('Notification sent', ['tag' => 'ServiceBus', 'event' => $event->getEventType()]);
+            Log::info(
+                'Notification sent',
+                [
+                    'tag' => 'ServiceBus',
+                    'event' => $event->getEventType(),
+                ]
+            );
         } catch (RequestException $exception) {
             if ($exception->getCode() == '403') {
-                Log::info('403 received. Logging in and retrying', ['tag' => 'ServiceBus']);
+                Log::info(
+                    '403 received. Logging in and retrying',
+                    [
+                        'tag' => 'ServiceBus',
+                    ]
+                );
 
                 // clear the invalid token //
                 Cache::forget($this->generateTokenKey());
@@ -141,7 +158,12 @@ class ServiceBusChannel
                 // there is no timeout on tokens, so cache it forever //
                 Cache::forever($this->generateTokenKey(), $token);
 
-                Log::info('Token received', ['tag' => 'ServiceBus']);
+                Log::info(
+                    'Token received',
+                    [
+                        'tag' => 'ServiceBus',
+                    ]
+                );
             } catch (RequestException $exception) {
                 throw CouldNotSendNotification::requestFailed($exception);
             }

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -69,7 +69,7 @@ class ServiceBusChannel
             Log::info(
                 'Service Bus disabled, event discarded',
                 [
-                    'tag' => 'ServiceBus',
+                    'tag'    => 'ServiceBus',
                     'params' => $params,
                 ]
             );
@@ -80,9 +80,9 @@ class ServiceBusChannel
         $token = $this->getToken();
 
         $headers = [
-            'Accept'        => 'application/json',
-            'Content-type'  => 'application/json',
-            'x-api-key'     => $token,
+            'Accept'       => 'application/json',
+            'Content-type' => 'application/json',
+            'x-api-key'    => $token,
         ];
 
         try {
@@ -90,15 +90,15 @@ class ServiceBusChannel
                 'POST',
                 $this->getUrl('events'),
                 [
-                    'headers'   => $headers,
-                    'json'      => [$params],
+                    'headers' => $headers,
+                    'json'    => [$params],
                 ]
             );
 
             Log::info(
                 'Notification sent',
                 [
-                    'tag' => 'ServiceBus',
+                    'tag'   => 'ServiceBus',
                     'event' => $event->getEventType(),
                 ]
             );

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -86,7 +86,8 @@ class ServiceBusChannel
         ];
 
         try {
-            $this->client->request('POST',
+            $this->client->request(
+                'POST',
                 $this->getUrl('events'),
                 [
                     'headers'   => $headers,
@@ -140,7 +141,8 @@ class ServiceBusChannel
 
         if (empty($token)) {
             try {
-                $body = $this->client->request('POST',
+                $body = $this->client->request(
+                    'POST',
                     $this->getUrl('login'),
                     [
                         'json' => [


### PR DESCRIPTION
- Use one log line for one event
- Add params to the context of the log call, don't use the message for this