### PR TITLE
Token not being updated because of wrong condition

### DIFF
--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -147,7 +147,7 @@ class ServiceBusChannel
     {
         $token = Cache::get($this->generateTokenKey());
 
-        if (empty($token)) {
+        if (isset($token)) {
             try {
                 $body = $this->client->request(
                     'POST',


### PR DESCRIPTION
`empty()` check always return true even when $token value is null. changing the condition to `isset()` checks against null value to ensure a valid token is always returned, otherwise forces the system to generate a new token