### PR TITLE
Fix token issue

### DIFF
--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -160,9 +160,11 @@ class ServiceBusChannel
 
                     switch ($response->getStatusCode()) {
                         case 200:
-                            $json = json_decode((string) $response->getBody());
+                            $body = json_decode((string) $response->getBody(), true);
 
-                            return $json->token;
+                            Log::info('ServiceBusChannel getToken response', ['body' => $body]);
+
+                            return $body['token'];
                         default:
                             throw CouldNotSendNotification::loginFailed($response);
                     }

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -164,8 +164,6 @@ class ServiceBusChannel
 
                     switch ($code) {
                         case 200:
-                            Log::info('ServiceBusChannel getToken response', ['body' => $body]);
-
                             return $body['token'];
                         default:
                             throw CouldNotSendNotification::loginFailed($response);

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -158,10 +158,12 @@ class ServiceBusChannel
                         ]
                     );
 
-                    switch ($response->getStatusCode()) {
-                        case 200:
-                            $body = json_decode((string) $response->getBody(), true);
+                    $body = json_decode((string) $response->getBody(), true);
 
+                    $code = (int) Arr::get($body, 'code', $response->getStatusCode());
+
+                    switch ($code) {
+                        case 200:
                             Log::info('ServiceBusChannel getToken response', ['body' => $body]);
 
                             return $body['token'];


### PR DESCRIPTION
Auth endpoint returns incorrect HTTP status in its responses. A 401 response uses a 200 status (for example). This change makes it use the JSON _code_ value first and fallback to the HTTP status if not found.