### PR TITLE
Ability to invalidate cached token

### DIFF
--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -146,7 +146,8 @@ class ServiceBusChannel
      */
     private function getToken(): string
     {
-        return Cache::rememberForever(
+        return Cache::tags('service-bus-token')
+            ->rememberForever(
             $this->generateTokenKey(),
             function () {
                 try {

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -189,7 +189,7 @@ class ServiceBusChannel
     public function generateTokenKey()
     {
         return md5(
-            'service-bus-token' .
+            'service-bus-token-with-tag' .
             Arr::get($this->ventureConfig, 'venture_config_id')
         );
     }

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -148,32 +148,32 @@ class ServiceBusChannel
     {
         return Cache::tags('service-bus-token')
             ->rememberForever(
-            $this->generateTokenKey(),
-            function () {
-                try {
-                    $response = $this->client->request(
-                        'POST',
-                        $this->getUrl('login'),
-                        [
-                            'json' => Arr::only($this->ventureConfig, ['username', 'password', 'venture_config_id']),
-                        ]
-                    );
+                $this->generateTokenKey(),
+                function () {
+                    try {
+                        $response = $this->client->request(
+                            'POST',
+                            $this->getUrl('login'),
+                            [
+                                'json' => Arr::only($this->ventureConfig, ['username', 'password', 'venture_config_id']),
+                            ]
+                        );
 
-                    $body = json_decode((string) $response->getBody(), true);
+                        $body = json_decode((string) $response->getBody(), true);
 
-                    $code = (int) Arr::get($body, 'code', $response->getStatusCode());
+                        $code = (int) Arr::get($body, 'code', $response->getStatusCode());
 
-                    switch ($code) {
-                        case 200:
-                            return $body['token'];
-                        default:
-                            throw CouldNotSendNotification::loginFailed($response);
+                        switch ($code) {
+                            case 200:
+                                return $body['token'];
+                            default:
+                                throw CouldNotSendNotification::loginFailed($response);
+                        }
+                    } catch (RequestException $exception) {
+                        throw CouldNotSendNotification::requestFailed($exception);
                     }
-                } catch (RequestException $exception) {
-                    throw CouldNotSendNotification::requestFailed($exception);
                 }
-            }
-        );
+            );
     }
 
     /**


### PR DESCRIPTION
This will allow ventures to easily invalidate cached token and force the service to re-authenticate for a fresh token when necessary.