### PR TITLE
Update from to node_id and update test suite

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,29 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="RIMU Service Bus Test Suite">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="MAIL_DRIVER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="RIMU Service Bus Test Suite">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="MAIL_DRIVER" value="array"/>
+    <env name="QUEUE_CONNECTION" value="sync"/>
+    <env name="SESSION_DRIVER" value="array"/>
+  </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    verbose="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+>
   <coverage>
     <include>
       <directory suffix=".php">src/</directory>

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -92,7 +92,6 @@ class ServiceBusChannel
                     'json' => [$params],
                 ]
             );
-
             if (!in_array($eventType, $dontReport)) {
                 Log::debug(
                     "$eventType service bus notification",

--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -283,7 +283,7 @@ class ServiceBusEvent
         return [
             'events' => [$this->eventType],
             'reference' => $this->reference,
-            'from' => $this->config['from'],
+            'from' => $this->config['node_id'],
             'created_at' => $this->createdAt->toISOString(),
             'version' => $this->config['version'],
             'route' => $this->route,

--- a/tests/ServiceBusChannelTest.php
+++ b/tests/ServiceBusChannelTest.php
@@ -23,7 +23,7 @@ class ServiceBusChannelTest extends TestCase
     public function testShouldCreateServiceBusChannelInstance()
     {
         $this->mockAll();
-        $serviceChannel = new ServiceBusChannel();
+        $serviceChannel = new ServiceBusChannel(config_v2());
 
         $this->assertNotNull($serviceChannel);
     }
@@ -38,6 +38,11 @@ class ServiceBusChannelTest extends TestCase
         $this->expectException(CouldNotSendNotification::class);
 
         $this->mockAll();
+        Cache::shouldReceive('rememberForever')
+            ->andReturn(true);
+        Cache::shouldReceive('forget')
+            ->andReturn(true);
+
         $serviceChannel = new ServiceBusChannel();
 
         $serviceChannel->send(new AnonymousNotifiable(), new TestNotification());
@@ -50,7 +55,7 @@ class ServiceBusChannelTest extends TestCase
     {
         Cache::shouldReceive('get')
             ->once()
-            ->with((new ServiceBusChannel())->generateTokenKey())
+            ->with((new ServiceBusChannel(config_v2()))->generateTokenKey())
             ->andReturn('value');
 
         Log::shouldReceive('debug')

--- a/tests/ServiceBusEventTest.php
+++ b/tests/ServiceBusEventTest.php
@@ -118,7 +118,7 @@ class ServiceBusEventTest extends TestCase
             ->withReference(uniqid())
             ->withRoute('api')
             ->withPayload([
-                'listing' => []
+                'listing' => [],
             ])
             ->createdAt(Carbon::now());
 
@@ -126,7 +126,7 @@ class ServiceBusEventTest extends TestCase
             ->withReference(uniqid())
             ->withRoute('api')
             ->withPayload([
-                'listing' => []
+                'listing' => [],
             ])
             ->createdAt(Carbon::now());
 

--- a/tests/ServiceBusEventTest.php
+++ b/tests/ServiceBusEventTest.php
@@ -15,14 +15,14 @@ class ServiceBusEventTest extends TestCase
 {
     public function testShouldCreateServiceBusEventInstance()
     {
-        $serviceBus = new ServiceBusEvent('test');
+        $serviceBus = new ServiceBusEvent('test', config_v2());
 
         $this->assertEquals('test', $serviceBus->getEventType());
     }
 
     public function testShouldCreateServiceBusEventInstanceViaStaticCall()
     {
-        $serviceBus = ServiceBusEvent::create('test');
+        $serviceBus = ServiceBusEvent::create('test', config_v2());
 
         $this->assertEquals('test', $serviceBus->getEventType());
     }
@@ -55,7 +55,7 @@ class ServiceBusEventTest extends TestCase
             'phone' => '0123456789',
         ];
 
-        $serviceBus = ServiceBusEvent::create('test')
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
             ->withAction('other', uniqid())
             ->withCulture('en')
             ->withReference(uniqid())
@@ -71,7 +71,7 @@ class ServiceBusEventTest extends TestCase
         $this->assertArrayHasKey('resource', $serviceBusData['payload']);
         $this->assertContains('test', $serviceBusData['events']);
 
-        $this->assertEquals([$resource], $serviceBusData['payload']['resource']);
+        $this->assertEquals($resource, $serviceBusData['payload']['resource']);
     }
 
     /**
@@ -88,7 +88,7 @@ class ServiceBusEventTest extends TestCase
             ],
         ];
 
-        $serviceBus = ServiceBusEvent::create('test')
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
             ->withAction('other', uniqid())
             ->withCulture('en')
             ->withReference(uniqid())
@@ -112,21 +112,22 @@ class ServiceBusEventTest extends TestCase
      */
     public function testShouldReturnCorrectEventForSpecificVersion()
     {
-        $version2Structure = [
-            'from' => '576192a7-8719-4dc0-a058-76f66973af0a',
-            'version' => '2.0.0',
-        ];
-
-        $serviceBusVersion1 = ServiceBusEvent::create('test')
+        $serviceBusVersion1 = ServiceBusEvent::create('test', config_v1())
             ->withAction('other', uniqid())
             ->withCulture('en')
             ->withReference(uniqid())
             ->withRoute('api')
+            ->withPayload([
+                'listing' => []
+            ])
             ->createdAt(Carbon::now());
 
-        $serviceBusVersion2 = ServiceBusEvent::create('test', $version2Structure)
+        $serviceBusVersion2 = ServiceBusEvent::create('test', config_v2())
             ->withReference(uniqid())
             ->withRoute('api')
+            ->withPayload([
+                'listing' => []
+            ])
             ->createdAt(Carbon::now());
 
         $serviceBusDataVersion1 = $serviceBusVersion1->getParams();

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -11,6 +11,45 @@ if (!function_exists('config')) {
      */
     function config($key = null, $default = null)
     {
-        return 'true';
+        return config_v1();
+    }
+}
+
+if (!function_exists('config_v1')) {
+    /**
+     * Mocked Laravel helper config values for v1 of eventbus.
+     *
+     * @return array
+     */
+    function config_v1()
+    {
+        return [
+            'enabled' => true,
+            'venture_config_id' => '123456789',
+            'username' => 'username',
+            'password' => 'password',
+            'version' => '1.0.0',
+            'culture' => 'en_GB',
+            'endpoint' => 'https://bus.staging.ritdu.tech/v1/',
+        ];
+    }
+}
+
+if (!function_exists('config_v2')) {
+    /**
+     * Mocked Laravel helper config values for v2 of the eventbus.
+     *
+     * @return array
+     */
+    function config_v2()
+    {
+        return [
+            'enabled' => true,
+            'node_id' => '123456789',
+            'username' => 'username',
+            'password' => 'password',
+            'version' => '2.0.0',
+            'endpoint' => 'https://bus.staging.ritdu.tech/v1/',
+        ];
     }
 }


### PR DESCRIPTION
During the upgrade to v2 on property, the config is expected to have `from` when it is suppose to be `node_id`.
Test suite is updated as it was outed 