### PR TITLE
SOL-185: Add SQS channel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,15 +1,19 @@
-; This file is for unifying the coding style for different editors and IDEs.
-; More information at http://editorconfig.org
-
+# EditorConfig is awesome: http://EditorConfig.org
 root = true
 
 [*]
 charset = utf-8
+end_of_line = lf
 indent_size = 4
 indent_style = space
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[{Makefile,*.mak}]
+indent_style = tab
+
 [*.md]
 trim_trailing_whitespace = false
+
+[{Makefile,*.mak,*.sh,*.yml}]
+indent_size = 2

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,1 @@
+layout php

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,2 @@
-# Path-based git attributes
-# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
-
-# Ignore all test and documentation with "export-ignore".
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/tests              export-ignore
+* text=auto eol=lf whitespace=tab-in-indent,blank-at-eol,tabwidth=4
+makefile text whitespace=-tab-in-indent,blank-at-eol,tabwidth=4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        illuminate-version:
+          - 9
+          - 10
+        php-version:
+          - 8.0
+          - 8.1
+          - 8.2
+        exclude:
+          - illuminate-version: 10
+            php-version: 8.0
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: |
+          composer require \
+            --no-ansi \
+            --no-interaction \
+            --no-progress \
+            --no-scripts \
+            --prefer-dist \
+            illuminate/support:^${{ matrix.illuminate-version }}
+
+      - name: Lint Code
+        run: vendor/bin/tlint
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
+/.envrc
+/.idea/
+/.phpunit.result.cache
+/composer.lock
 /vendor
-build
-composer.lock
-composer.phar
-.idea/
-.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -12,28 +12,25 @@
         }
     ],
     "require": {
-        "php": ">=7.2 || ^8.0 || ^8.1",
+        "php": "^8",
         "ext-json": "*",
         "ext-pcre": "*",
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^5.3 || ^6 || ^7",
-        "guzzlehttp/promises": "~1.0",
-        "guzzlehttp/psr7": "^1.4.1",
-        "illuminate/notifications": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "ramsey/uuid": "^3.7 || ^4.1"
+        "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/promises": "^2",
+        "guzzlehttp/psr7": "^1 || ^2",
+        "illuminate/notifications": "^9 || ^10",
+        "illuminate/support": "^9 || ^10",
+        "ramsey/uuid": "^4"
     },
     "require-dev": {
         "ext-dom": "*",
         "ext-openssl": "*",
         "ext-pcntl": "*",
         "ext-sockets": "*",
-        "behat/behat": "~3.0",
-        "doctrine/cache": "~1.4",
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.0 || ^9.5",
-        "psr/cache": "^1.0",
-        "psr/simple-cache": "^1.0"
+        "mockery/mockery": "^1",
+        "phpunit/phpunit": "^9.5",
+        "tightenco/tlint": "^8 || ^9"
     },
     "extra": {
         "include_files": [

--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -283,7 +283,7 @@ class ServiceBusEvent
         return [
             'events' => [$this->eventType],
             'reference' => $this->reference,
-            'from' => $this->config['node_id'],
+            'from' => $this->config['from'] ?? $this->config['node_id'],
             'created_at' => $this->createdAt->toISOString(),
             'version' => $this->config['version'],
             'route' => $this->route,

--- a/src/ServiceBusSQSChannel.php
+++ b/src/ServiceBusSQSChannel.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Ringierimu\ServiceBusNotificationsChannel;
+
+use Aws\Sqs\SqsClient;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+
+class ServiceBusSQSChannel
+{
+    protected SqsClient $sqs;
+
+    public function __construct(array $config = [])
+    {
+        $this->config = $config ?: config('services.service_bus');
+
+        $this->sqs = new SqsClient([
+            'region' => Arr::get($this->config, 'sqs.region'),
+            'version' => 'latest',
+            'credentials' => [
+                'key' => Arr::get($this->config, 'sqs.key'),
+                'secret' => Arr::get($this->config, 'sqs.secret'),
+            ],
+        ]);
+    }
+
+    public function send($notifiable, Notification $notification)
+    {
+        /** @var ServiceBusEvent $event */
+        $event = $notification->toServiceBus($notifiable);
+        $eventType = $event->getEventType();
+        $params = $event->getParams();
+        $dontReport = Arr::get($this->config, 'dont_report', []);
+
+        if (Arr::get($this->config, 'enabled') == false) {
+            if (!in_array($eventType, $dontReport)) {
+                Log::debug(
+                    "$eventType service bus notification [disabled]",
+                    [
+                        'event' => $eventType,
+                        'params' => $params,
+                        'tags' => [
+                            'service-bus',
+                        ],
+                    ]
+                );
+            }
+
+            return;
+        }
+
+        $message = $notification
+            ->toServiceBus($notifiable)
+            ->getParams();
+
+        $response = $this->sqs->sendMessage([
+            'QueueUrl' => Arr::get($this->config, 'sqs.queue_url'),
+            'MessageBody' => json_encode($message),
+            'MessageGroupId' => $message['from'],
+        ]);
+
+        $event = $message['events'][0];
+
+        Log::info("{$event} sent to bus queue", [
+            'message_id' => $response->get('MessageId'),
+            'message' => $message,
+        ]);
+    }
+}

--- a/tlint.json
+++ b/tlint.json
@@ -1,0 +1,10 @@
+{
+  "preset": "laravel",
+  "disabled": [
+    "SpaceAfterSoleNotOperator",
+    "NoParensEmptyInstantiations",
+    "OneLineBetweenClassVisibilityChanges",
+    "ModelMethodOrder",
+    "ConcatenationNoSpacing"
+  ]
+}


### PR DESCRIPTION
Add direct delivery to a bus SQS queue.

The following new config is required under the `services.service_bus.sqs` key:
* region - AWS region the queue is located in
* key - AWS access key for the user that has access to the queue
* secret - AWS secret key for the user that has access to the queue
* queue_url - AWS SQS queue URL

In addition, notifications that use SQS delivery must return the new SQS channel in the notification class:
```
use Illuminate\Notifications\Notification;
use Ringierimu\ServiceBusNotificationsChannel\ServiceBusSQSChannel;

class MyNotification extends Notification
{
    // ...
    public function via(): array
    {
        return [
            ServiceBusSQSChannel::class,
        ];
    }
    // ...
}
```