### PR TITLE
Per-entity MessageGroupId routing + debounce_key + Laravel 13 (stacked on #47)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,19 +15,21 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.4]
-        laravel: ['11.*', '12.*']
+        laravel: ['11.*', '12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: '11.*'
             testbench: '^9.0'
           - laravel: '12.*'
             testbench: '^10.0'
+          - laravel: '13.*'
+            testbench: '^11.0'
 
     name: PHP ${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -43,7 +45,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Changed
-- **BREAKING:** Minimum PHP version raised to 8.3
-- **BREAKING:** Minimum Laravel version raised to 11.0 (supports 11.x and 12.x)
-- Migrated test suite from PHPUnit to Pest 4
-- Applied PHP 8.3 modernization via Rector (readonly properties, match expressions, named arguments)
-- Refactored `ServiceBusChannel` and `ServiceBusSQSChannel` to accept optional HTTP/SQS clients via constructor injection
-- `ServiceBusSQSChannel` now auto-detects FIFO queues by `.fifo` URL suffix and only sets `MessageGroupId`/`MessageDeduplicationId` for FIFO queues; standard queues are now supported
-
 ### Added
+- Laravel 13 support (released 2026-03-17 — zero breaking changes from 12.x)
+- `debounce_key` field on v2 event params: joins every payload entity's `reference` into `key1=ref1_key2=ref2_...` for downstream message deduplication on the full reference combination. Returns `null` if any entity is missing a reference.
+- Per-event-type `MessageGroupId` for `ServiceBusSQSChannel`: appends a primary-entity tag (e.g. `listing={reference}`, `user={reference}`) so SQS FIFO ordering partitions by the entity that owns the event. Unknown event types fall back to bare `from`.
 - Full test coverage for `ServiceBusChannel` and `ServiceBusSQSChannel`
 - GitHub Actions CI workflow replacing legacy `build.yml`
 - README badges for CI status, PHP version, and Laravel version
 - `ServiceBusSQSChannel` rebuilds its SQS client and retries once when AWS returns a stale-credential error (`ExpiredToken`, `ExpiredTokenException`, `InvalidClientTokenId`, `UnrecognizedClientException`, `RequestExpired`, `TokenRefreshRequired`); non-credential errors are not retried and bubble up. Note: if Laravel's config is cached (`php artisan config:cache`), the rebuild reads the same cached credentials — clear the config cache when rotating keys.
+
+### Changed
+- **BREAKING:** Minimum PHP version raised to 8.3
+- **BREAKING:** Minimum Laravel version raised to 11.0 (supports 11.x, 12.x, and 13.x)
+- Migrated test suite from PHPUnit to Pest 4
+- Applied PHP 8.3 modernization via Rector (readonly properties, match expressions, named arguments)
+- Refactored `ServiceBusChannel` and `ServiceBusSQSChannel` to accept optional HTTP/SQS clients via constructor injection
+- `ServiceBusSQSChannel` now auto-detects FIFO queues by `.fifo` URL suffix and only sets `MessageGroupId`/`MessageDeduplicationId` for FIFO queues; standard queues are now supported
+- `ServiceBusSQSChannel::send()` no longer double-resolves the event (`toServiceBus()` was being called twice).
+- `ServiceBusEvent::getPayload()` is now null-safe (returns `[]` when no payload was set), so v2 events built without `withPayload()` no longer throw on `getParams()`.
+- Bumped GitHub Actions: `actions/checkout@v4` → `@v6`, `actions/cache@v4` → `@v5`.
 
 ### Removed
 - Support for PHP < 8.3
 - Support for Laravel < 11.0
 - Legacy `build.yml` GitHub Actions workflow
 - `helpers.php` test helper file (inlined into test files)
+- Legacy constraints on dev/optional deps: `nunomaduro/collision ^7.0`, `tightenco/tlint ^8`, `guzzlehttp/psr7 ^1` — all narrowed to the latest major.
 
 ## [3.10.0] - 2025-02-26
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 [![CI](https://github.com/RingierIMU/service-bus-notifications-channel/actions/workflows/main.yml/badge.svg)](https://github.com/RingierIMU/service-bus-notifications-channel/actions/workflows/main.yml)
 ![PHP Version](https://img.shields.io/badge/php-8.3%2B-777BB4?logo=php&logoColor=white)
-![Laravel Version](https://img.shields.io/badge/laravel-11%20%7C%2012-FF2D20?logo=laravel&logoColor=white)
+![Laravel Version](https://img.shields.io/badge/laravel-11%20%7C%2012%20%7C%2013-FF2D20?logo=laravel&logoColor=white)
 
 This is a Laravel package that provides notification channels for
 sending notifications to the _RingierSA Service Bus_.
 
 ## Supported Versions
 
-| PHP | Laravel 11.x | Laravel 12.x |
-|-----|:------------:|:------------:|
-| 8.3 | Yes | Yes |
-| 8.4 | Yes | Yes |
+| PHP | Laravel 11.x | Laravel 12.x | Laravel 13.x |
+|-----|:------------:|:------------:|:------------:|
+| 8.3 | Yes | Yes | Yes |
+| 8.4 | Yes | Yes | Yes |
 
 ## Requirements
 
 - PHP 8.3 or higher
-- Laravel 11.x or 12.x
+- Laravel 11.x, 12.x, or 13.x
 
 ## Installation
 
@@ -120,6 +120,8 @@ For high volume notifications, you can send directly to an `SQS` queue in the se
 
 This removes the need to queue it in your app, and provides a more reliable way to send high volume notifications.
 
+### Configuration
+
 Add the following to your config:
 
 ```php
@@ -169,7 +171,7 @@ We recommend you do not queue the notification. Send it `afterResponse`, the tim
 
 Both FIFO and standard SQS queues are supported. The channel detects the queue type from the URL:
 
-- URLs ending in `.fifo` are treated as FIFO queues. `MessageGroupId` is set to the configured `from`/`node_id`, and `MessageDeduplicationId` is set to the `md5` of the message body so dedup works whether or not `ContentBasedDeduplication` is enabled on the queue.
+- URLs ending in `.fifo` are treated as FIFO queues. `MessageGroupId` is routed per primary entity for known event types (e.g. `{from}_listing={reference}`, `{from}_user={reference}`) so FIFO ordering is preserved per entity rather than globally serialised; unknown event types fall back to bare `{from}`. `MessageDeduplicationId` is set to the `md5` of the message body so dedup works whether or not `ContentBasedDeduplication` is enabled on the queue.
 - All other URLs are treated as standard queues — neither field is sent.
 
 ### Credential refresh on transient AWS auth errors
@@ -177,6 +179,10 @@ Both FIFO and standard SQS queues are supported. The channel detects the queue t
 If the AWS SDK returns a stale-credential error (`ExpiredToken`, `ExpiredTokenException`, `InvalidClientTokenId`, `UnrecognizedClientException`, `RequestExpired`, `TokenRefreshRequired`), the channel rebuilds its SQS client from the current config and retries the send once. Non-credential errors are not retried and bubble up to the caller.
 
 If you cache Laravel config (`php artisan config:cache`), remember to clear it (`php artisan config:clear`) when rotating AWS credentials — the rebuild reads the same cached values otherwise.
+
+### debounce_key
+
+v2 event payloads include a `debounce_key` field derived from every payload entity's `reference` (e.g. `listing=abc_user=42`). It is emitted as message body data — downstream consumers can use it to dedupe at the application layer over the full reference combination, independent of SQS's content-based dedup. The field is `null` if any payload entity is missing a `reference`.
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "ringierimu/service-bus-notifications-channel",
   "description": "Service Bus Notifications Channel",
-  "homepage": "https://github.com/RingierIMU/service-bus-notifications-channel",
   "license": "MIT",
   "authors": [
     {
@@ -11,30 +10,24 @@
       "role": "Developer"
     }
   ],
+  "homepage": "https://github.com/RingierIMU/service-bus-notifications-channel",
   "require": {
     "php": "^8.3",
     "ext-json": "*",
-    "illuminate/notifications": "^11.0 || ^12.0",
-    "illuminate/support": "^11.0 || ^12.0",
     "guzzlehttp/guzzle": "^7",
     "guzzlehttp/promises": "^2",
-    "guzzlehttp/psr7": "^1 || ^2",
+    "guzzlehttp/psr7": "^2",
+    "illuminate/notifications": "^11.0 || ^12.0 || ^13.0",
+    "illuminate/support": "^11.0 || ^12.0 || ^13.0",
     "ramsey/uuid": "^4.0"
   },
   "require-dev": {
     "aws/aws-sdk-php": "^3.0",
     "mockery/mockery": "^1.6",
-    "tightenco/tlint": "^8 || ^9",
-    "orchestra/testbench": "^9.0 || ^10.0",
-    "nunomaduro/collision": "^7.0 || ^8.0",
-    "pestphp/pest": "^4.0"
-  },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "Ringierimu\\ServiceBusNotificationsChannel\\ServiceBusServiceProvider"
-      ]
-    }
+    "nunomaduro/collision": "^8.0",
+    "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+    "pestphp/pest": "^4.0",
+    "tightenco/tlint": "^9"
   },
   "autoload": {
     "psr-4": {
@@ -46,13 +39,20 @@
       "Ringierimu\\ServiceBusNotificationsChannel\\Tests\\": "tests/"
     }
   },
-  "scripts": {
-    "lint": "vendor/bin/tlint",
-    "test": "vendor/bin/pest"
-  },
   "config": {
     "allow-plugins": {
       "pestphp/pest-plugin": true
     }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Ringierimu\\ServiceBusNotificationsChannel\\ServiceBusServiceProvider"
+      ]
+    }
+  },
+  "scripts": {
+    "lint": "vendor/bin/tlint",
+    "test": "vendor/bin/pest"
   }
 }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -7,9 +7,6 @@ use Illuminate\Support\Facades\Log;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
-/**
- * Class CouldNotSendNotification.
- */
 class CouldNotSendNotification extends Exception
 {
     public static function authFailed(Throwable $exception): static

--- a/src/Exceptions/InvalidConfigException.php
+++ b/src/Exceptions/InvalidConfigException.php
@@ -4,9 +4,6 @@ namespace Ringierimu\ServiceBusNotificationsChannel\Exceptions;
 
 use Exception;
 
-/**
- * Class InvalidConfigException.
- */
 class InvalidConfigException extends Exception
 {
 }

--- a/src/ServiceBusChannel.php
+++ b/src/ServiceBusChannel.php
@@ -12,33 +12,26 @@ use Illuminate\Support\Facades\Log;
 use Ringierimu\ServiceBusNotificationsChannel\Exceptions\CouldNotSendNotification;
 use Throwable;
 
-/**
- * Class ServiceBusChannel.
- */
 class ServiceBusChannel
 {
-    private readonly Client $client;
-
     protected bool $hasAttemptedLogin = false;
 
     protected array $config = [];
 
-    /**
-     * ServiceBusChannel constructor.
-     */
+    private readonly Client $client;
+
     public function __construct(array $config = [], Client|null $client = null)
     {
         $this->config = $config ?: config('services.service_bus');
 
-        $this->client = $client ?? new Client([
-            'base_uri' => Arr::get($this->config, 'endpoint'),
-        ]);
+        $this->client = $client ?? new Client(
+            [
+                'base_uri' => Arr::get($this->config, 'endpoint'),
+            ],
+        );
     }
 
     /**
-     * Send the given notification.
-     *
-     *
      * @throws CouldNotSendNotification
      * @throws GuzzleException
      * @throws Throwable
@@ -53,11 +46,14 @@ class ServiceBusChannel
 
         if (Arr::get($this->config, 'enabled') == false) {
             if (!in_array($eventType, $dontReport)) {
-                Log::debug("$eventType service bus notification [disabled]", [
-                    'event' => $eventType,
-                    'params' => $params,
-                    'tags' => ['service-bus'],
-                ]);
+                Log::debug(
+                    "$eventType service bus notification [disabled]",
+                    [
+                        'event' => $eventType,
+                        'params' => $params,
+                        'tags' => ['service-bus'],
+                    ],
+                );
             }
 
             return;
@@ -74,34 +70,38 @@ class ServiceBusChannel
         try {
             $response = $this->client->request(
                 'POST',
-                $this->getUrl('events'),
+                'events',
                 [
                     'headers' => $headers,
                     'json' => [$params],
                 ],
             );
 
-            Log::info("$eventType service bus notification", [
-                'event' => $eventType,
-                'params' => $params,
-                'tags' => ['service-bus'],
-                'status' => $response->getStatusCode(),
-            ]);
+            Log::info(
+                "$eventType service bus notification",
+                [
+                    'event' => $eventType,
+                    'params' => $params,
+                    'tags' => ['service-bus'],
+                    'status' => $response->getStatusCode(),
+                ],
+            );
         } catch (RequestException $exception) {
             $code = $exception->getCode();
 
             if (in_array($code, [401, 403])) {
-                Log::info("$code received. Logging in and retrying.", [
-                    'event' => $eventType,
-                    'params' => $params,
-                    'tags' => ['service-bus'],
-                ]);
+                Log::info(
+                    "$code received. Logging in and retrying.",
+                    [
+                        'event' => $eventType,
+                        'params' => $params,
+                        'tags' => ['service-bus'],
+                    ],
+                );
 
-                // clear the invalid token //
                 Cache::forget($this->generateTokenKey());
 
                 if (!$this->hasAttemptedLogin) {
-                    // redo the call which will now redo the login //
                     $this->hasAttemptedLogin = true;
                     $this->send($notifiable, $notification);
                 } else {
@@ -119,72 +119,53 @@ class ServiceBusChannel
      * @throws CouldNotSendNotification
      * @throws GuzzleException
      */
-    private function getToken(): string
+    protected function getToken(): string
     {
-        return Cache::rememberForever($this->generateTokenKey(), function () {
-            try {
-                $version = (int) ($this->config['version']);
+        return Cache::rememberForever(
+            $this->generateTokenKey(),
+            function () {
+                try {
+                    $response = $this->client->request(
+                        'POST',
+                        'login',
+                        [
+                            'json' => Arr::only(
+                                $this->config,
+                                [
+                                    'username',
+                                    'password',
+                                    $this->tenantConfigKey(),
+                                ],
+                            ),
+                        ],
+                    );
 
-                if ($version < 2) {
-                    $response = $this->client->request(
-                        'POST',
-                        $this->getUrl('login'),
-                        [
-                            'json' => Arr::only($this->config, [
-                                'username',
-                                'password',
-                                'venture_config_id',
-                            ]),
-                        ],
+                    $body = json_decode((string) $response->getBody(), true);
+
+                    $code = (int) Arr::get(
+                        $body,
+                        'code',
+                        $response->getStatusCode(),
                     );
-                } else {
-                    $response = $this->client->request(
-                        'POST',
-                        $this->getUrl('login'),
-                        [
-                            'json' => Arr::only($this->config, [
-                                'username',
-                                'password',
-                                'node_id',
-                            ]),
-                        ],
-                    );
+
+                    return match ($code) {
+                        200 => $body['token'],
+                        default => throw CouldNotSendNotification::loginFailed($response),
+                    };
+                } catch (RequestException $exception) {
+                    throw CouldNotSendNotification::requestFailed($exception);
                 }
-
-                $body = json_decode((string) $response->getBody(), true);
-
-                $code = (int) Arr::get(
-                    $body,
-                    'code',
-                    $response->getStatusCode(),
-                );
-
-                return match ($code) {
-                    200 => $body['token'],
-                    default => throw CouldNotSendNotification::loginFailed($response),
-                };
-            } catch (RequestException $exception) {
-                throw CouldNotSendNotification::requestFailed($exception);
-            }
-        });
+            },
+        );
     }
 
-    private function getUrl(string $endpoint): string
+    protected function generateTokenKey(): string
     {
-        return $endpoint;
+        return md5('service-bus-token' . Arr::get($this->config, $this->tenantConfigKey()));
     }
 
-    public function generateTokenKey(): string
+    protected function tenantConfigKey(): string
     {
-        $version = (int) ($this->config['version']);
-
-        if ($version < 2) {
-            return md5(
-                'service-bus-token'
-                    . Arr::get($this->config, 'venture_config_id'),
-            );
-        }
-
-        return md5('service-bus-token' . Arr::get($this->config, 'node_id'));
+        return ((int) $this->config['version']) < 2 ? 'venture_config_id' : 'node_id';
     }
 }

--- a/src/ServiceBusEvent.php
+++ b/src/ServiceBusEvent.php
@@ -3,25 +3,12 @@
 namespace Ringierimu\ServiceBusNotificationsChannel;
 
 use Carbon\Carbon;
-use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Ramsey\Uuid\Uuid;
 use Ringierimu\ServiceBusNotificationsChannel\Exceptions\InvalidConfigException;
 use Throwable;
 
-/**
- * Class ServiceBusEvent.
- *
- * @property string eventType
- * @property string reference
- * @property string culture
- * @property string actionType
- * @property string actionReference
- * @property Carbon createdAt
- * @property array payload
- * @property string route
- */
 class ServiceBusEvent
 {
     public static $actionTypes = [
@@ -50,14 +37,21 @@ class ServiceBusEvent
 
     protected $config = [];
 
-    /**
-     * ServiceBusEvent constructor.
-     */
     public function __construct(protected string $eventType, array $config = [])
     {
         $this->config = $config ?: config('services.service_bus');
         $this->createdAt = Carbon::now();
         $this->reference = $this->generateUUID();
+    }
+
+    /**
+     * Generates a v4 UUID.
+     *
+     * @throws Throwable
+     */
+    protected function generateUUID(): string
+    {
+        return Uuid::uuid4()->toString();
     }
 
     /**
@@ -108,12 +102,14 @@ class ServiceBusEvent
      */
     public function withAction(string $type, string $reference): static
     {
-        if (in_array($type, self::$actionTypes)) {
-            $this->actionType = $type;
-            $this->actionReference = $reference;
-        } else {
-            throw new InvalidConfigException('Action type must be on of the following: ' . print_r(self::$actionTypes, true));
+        if (!in_array($type, self::$actionTypes)) {
+            throw new InvalidConfigException(
+                'Action type must be one of the following: ' . implode(', ', self::$actionTypes),
+            );
         }
+
+        $this->actionType = $type;
+        $this->actionReference = $reference;
 
         return $this;
     }
@@ -131,13 +127,7 @@ class ServiceBusEvent
     }
 
     /**
-     * The entity that the event applies to, where relevant, eg, the user that logged in.
-     *
-     * This needs to a Illuminate\Http\Resources\Json\JsonResource\JsonResource representing the entity
-     *
      * @deprecated Use withResource and withPayload instead.
-     *
-     * @return $this
      */
     public function withResources(string $resourceName, array $resource): static
     {
@@ -146,29 +136,6 @@ class ServiceBusEvent
         return $this;
     }
 
-    /**
-     * @param array|JsonResource $resource
-     *
-     * @return this
-     */
-    public function withResource(string $resourceName, $resource, Request $request = null): static
-    {
-        if (!is_array($resource)) {
-            if ($resource instanceof JsonResource) {
-                $resource = $resource->toArray($request);
-            } else {
-                throw new Exception('Unhandled resource type: ' . $resourceName . ' ' . json_encode($resource));
-            }
-        }
-
-        $this->payload[$resourceName] = $resource;
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
     public function withPayload(array $payload): static
     {
         $this->payload = [];
@@ -181,6 +148,28 @@ class ServiceBusEvent
     }
 
     /**
+     * @param array|JsonResource $resource
+     *
+     * @throws InvalidConfigException
+     */
+    public function withResource(string $resourceName, $resource, Request|null $request = null): static
+    {
+        if (!is_array($resource)) {
+            if (!$resource instanceof JsonResource) {
+                throw new InvalidConfigException(
+                    'Unhandled resource type: ' . $resourceName . ' ' . json_encode($resource),
+                );
+            }
+
+            $resource = $resource->toArray($request);
+        }
+
+        $this->payload[$resourceName] = $resource;
+
+        return $this;
+    }
+
+    /**
      * Date time of the event creation on the event source in ISO8601/RFC3339 format.
      */
     public function createdAt(Carbon $createdAtDate): static
@@ -188,32 +177,6 @@ class ServiceBusEvent
         $this->createdAt = $createdAtDate;
 
         return $this;
-    }
-
-    /**
-     * Returns the culture to be use, will use config services.service_bus.culture if not set on the event.
-     */
-    protected function getCulture(): string
-    {
-        return $this->culture ?? $this->config['culture'];
-    }
-
-    /**
-     * Gets the extra data to be sent as the payload param.
-     */
-    protected function getPayload(): array
-    {
-        return $this->payload;
-    }
-
-    /**
-     * Generates a v4 UUID.
-     *
-     * @throws Throwable
-     */
-    private function generateUUID(): string
-    {
-        return Uuid::uuid4()->toString();
     }
 
     /**
@@ -246,11 +209,50 @@ class ServiceBusEvent
             'events' => [$this->eventType],
             'reference' => $this->reference,
             'from' => $this->config['from'] ?? $this->config['node_id'],
+            'debounce_key' => $this->getDebounceKey(),
             'created_at' => $this->createdAt->toISOString(),
             'version' => $this->config['version'],
             'route' => $this->route,
             'payload' => $this->getPayload(),
         ];
+    }
+
+    /**
+     * Returns the culture to be use, will use config services.service_bus.culture if not set on the event.
+     */
+    protected function getCulture(): string
+    {
+        return $this->culture ?? $this->config['culture'];
+    }
+
+    /**
+     * Gets the extra data to be sent as the payload param.
+     */
+    protected function getPayload(): array
+    {
+        return $this->payload ?? [];
+    }
+
+    protected function getDebounceKey(): string|null
+    {
+        $debounceKV = collect($this->getPayload())
+            ->mapWithKeys(
+                fn ($value, $key) => [$key => $value['reference'] ?? null],
+            );
+
+        $debounceKVCount = $debounceKV->count();
+        if (!$debounceKVCount) {
+            return null;
+        }
+
+        $debounceKeys = $debounceKV->filter();
+        if ($debounceKeys->count() !== $debounceKVCount) {
+            return null;
+        }
+
+        return $debounceKeys
+            ->map(fn ($value, $key) => "{$key}={$value}")
+            ->implode('_');
     }
 
     public function getEventType(): string

--- a/src/ServiceBusSQSChannel.php
+++ b/src/ServiceBusSQSChannel.php
@@ -93,7 +93,7 @@ class ServiceBusSQSChannel
         ];
 
         if ($this->isFifoQueue($queueUrl)) {
-            $payload['MessageGroupId'] = $params['from'];
+            $payload['MessageGroupId'] = $this->getMessageGroupId($params);
             // Explicit MessageDeduplicationId so dedup works regardless of
             // whether ContentBasedDeduplication is enabled on the queue.
             $payload['MessageDeduplicationId'] = md5($body);
@@ -144,6 +144,82 @@ class ServiceBusSQSChannel
         }
 
         throw $lastException;
+    }
+
+    protected function getMessageGroupId(array $message): string
+    {
+        $messageGroupId = $message['from'];
+
+        $append = match ($message['events'][0] ?? null) {
+            'ListingCreated',
+            'ListingUpdated',
+            'ListingDeleted',
+            'ListingLeadCreated',
+            'ListingPromoted',
+            'ListingProductsAdded',
+            'ListingProductsRemoved',
+            'ListingShared',
+            'ListingFavouriteCreated',
+            'ListingFavouriteRemoved' => 'listing=' . $message['payload']['listing']['reference'],
+
+            'TopicCreated',
+            'TopicUpdated',
+            'TopicDeleted' => 'topic=' . $message['payload']['topic']['reference'],
+
+            'AlertCreated',
+            'AlertUpdated',
+            'AlertDeleted',
+            'AlertSent' => 'user_alert=' . $message['payload']['alert']['user']['reference'],
+
+            'AdvertiserCreated',
+            'AdvertiserUpdated',
+            'AdvertiserDeleted',
+            'AdvertiserProductsAdded',
+            'AdvertiserProductsRemoved',
+            'AdvertiserLeadCreated' => 'advertiser=' . $message['payload']['advertiser']['reference'],
+
+            'UserCreated',
+            'UserUpdated',
+            'UserDeleted',
+            'UserLogin',
+            'UserLogout',
+            'UserPasswordRequest',
+            'UserPasswordReset',
+            'UserVerified',
+            'UserProductsAdded',
+            'UserProductsRemoved',
+            'UserLeadCreated',
+            'UserAnonymized' => 'user=' . $message['payload']['user']['reference'],
+
+            'SiteLeadCreated' => 'site_lead',
+
+            'Callback',
+            'Error' => 'callback',
+
+            'TestRunsDispatched',
+            'TestRunReceived',
+            'TestRunStarted',
+            'TestRunComplete' => 'test_run',
+
+            'ArticleCreated',
+            'ArticleUpdated',
+            'ArticleDeleted' => 'article=' . $message['payload']['article']['reference'],
+
+            'AuthorCreated',
+            'AuthorUpdated',
+            'AuthorDeleted' => 'author=' . $message['payload']['author']['reference'],
+
+            'SportEventCreated',
+            'SportEventUpdated',
+            'SportEventDeleted' => 'sport_event=' . $message['payload']['sport_event']['reference'],
+
+            'NewsletterSubscribed',
+            'NewsletterUnsubscribed' => 'newsletter',
+
+            default => null,
+        };
+
+        return $append ? $messageGroupId . '_' . $append : $messageGroupId;
     }
 
     protected function buildSqsClient(): SqsClient

--- a/src/ServiceBusServiceProvider.php
+++ b/src/ServiceBusServiceProvider.php
@@ -3,25 +3,7 @@
 namespace Ringierimu\ServiceBusNotificationsChannel;
 
 use Illuminate\Support\ServiceProvider;
-use Override;
 
-/**
- * Class ServiceBusServiceProvider.
- */
 class ServiceBusServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap the application services.
-     */
-    public function boot(): void
-    {
-    }
-
-    /**
-     * Register the application services.
-     */
-    #[Override]
-    public function register(): void
-    {
-    }
 }

--- a/tests/ServiceBusChannelTest.php
+++ b/tests/ServiceBusChannelTest.php
@@ -14,29 +14,35 @@ use Ringierimu\ServiceBusNotificationsChannel\Tests\TestNotification;
 
 function makeV2Config(array $overrides = []): array
 {
-    return array_merge([
-        'enabled' => true,
-        'node_id' => '123456789',
-        'username' => 'user',
-        'password' => 'pass',
-        'version' => '2.0.0',
-        'endpoint' => 'https://bus.example.com/v1/',
-        'dont_report' => [],
-    ], $overrides);
+    return array_merge(
+        [
+            'enabled' => true,
+            'node_id' => '123456789',
+            'username' => 'user',
+            'password' => 'pass',
+            'version' => '2.0.0',
+            'endpoint' => 'https://bus.example.com/v1/',
+            'dont_report' => [],
+        ],
+        $overrides,
+    );
 }
 
 function makeV1Config(array $overrides = []): array
 {
-    return array_merge([
-        'enabled' => true,
-        'venture_config_id' => '123456789',
-        'username' => 'user',
-        'password' => 'pass',
-        'version' => '1.0.0',
-        'culture' => 'en_GB',
-        'endpoint' => 'https://bus.example.com/v1/',
-        'dont_report' => [],
-    ], $overrides);
+    return array_merge(
+        [
+            'enabled' => true,
+            'venture_config_id' => '123456789',
+            'username' => 'user',
+            'password' => 'pass',
+            'version' => '1.0.0',
+            'culture' => 'en_GB',
+            'endpoint' => 'https://bus.example.com/v1/',
+            'dont_report' => [],
+        ],
+        $overrides,
+    );
 }
 
 function makeClient(array $responses): Client
@@ -47,162 +53,196 @@ function makeClient(array $responses): Client
 }
 
 // Test 1 (COVR-06): Disabled channel logs debug
-it('logs debug when disabled and event not in dont_report', function () {
-    Log::shouldReceive('debug')
-        ->once()
-        ->with(
-            \Mockery::pattern('/test.*\[disabled\]/'),
-            \Mockery::type('array'),
-        );
+it(
+    'logs debug when disabled and event not in dont_report',
+    function () {
+        Log::shouldReceive('debug')
+            ->once()
+            ->with(
+                Mockery::pattern('/test.*\[disabled\]/'),
+                Mockery::type('array'),
+            );
 
-    $client = makeClient([]);
-    $channel = new ServiceBusChannel(makeV2Config(['enabled' => false]), $client);
+        $client = makeClient([]);
+        $channel = new ServiceBusChannel(makeV2Config(['enabled' => false]), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-});
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+);
 
 // Test 2 (COVR-06): Disabled channel with dont_report suppresses log
-it('suppresses log when disabled and event in dont_report', function () {
-    Log::shouldReceive('debug')->never();
+it(
+    'suppresses log when disabled and event in dont_report',
+    function () {
+        Log::shouldReceive('debug')->never();
 
-    $client = makeClient([]);
-    $channel = new ServiceBusChannel(
-        makeV2Config(['enabled' => false, 'dont_report' => ['test']]),
-        $client,
-    );
+        $client = makeClient([]);
+        $channel = new ServiceBusChannel(
+            makeV2Config(['enabled' => false, 'dont_report' => ['test']]),
+            $client,
+        );
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-});
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+);
 
 // Test 3 (baseline): Happy path v2
-it('sends event successfully with v2 config', function () {
-    Log::spy();
+it(
+    'sends event successfully with v2 config',
+    function () {
+        Log::spy();
 
-    $client = makeClient([
-        new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200])),
-        new Response(200, [], 'OK'),
-    ]);
+        $client = makeClient(
+            [
+                new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200])),
+                new Response(200, [], 'OK'),
+            ],
+        );
 
-    $channel = new ServiceBusChannel(makeV2Config(), $client);
+        $channel = new ServiceBusChannel(makeV2Config(), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
 
-    Log::shouldHaveReceived('info')->once();
-});
+        Log::shouldHaveReceived('info')->once();
+    },
+);
 
 // Test 4 (baseline): Happy path v1
-it('sends event successfully with v1 config', function () {
-    Log::spy();
+it(
+    'sends event successfully with v1 config',
+    function () {
+        Log::spy();
 
-    $client = makeClient([
-        new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200])),
-        new Response(200, [], 'OK'),
-    ]);
+        $client = makeClient(
+            [
+                new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200])),
+                new Response(200, [], 'OK'),
+            ],
+        );
 
-    $channel = new ServiceBusChannel(makeV1Config(), $client);
+        $channel = new ServiceBusChannel(makeV1Config(), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
 
-    Log::shouldHaveReceived('info')->once();
-});
+        Log::shouldHaveReceived('info')->once();
+    },
+);
 
 // Test 5 (COVR-03): 401 retry success
-it('retries after 401 with fresh token', function () {
-    Log::spy();
+it(
+    'retries after 401 with fresh token',
+    function () {
+        Log::spy();
 
-    $loginResponse = new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200]));
-    $reLoginResponse = new Response(200, [], json_encode(['token' => 'fresh-token', 'code' => 200]));
-    $eventsError = RequestException::create(
-        new Request('POST', 'events'),
-        new Response(401, [], 'Unauthorized'),
-    );
-    $eventsSuccess = new Response(200, [], 'OK');
+        $loginResponse = new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200]));
+        $reLoginResponse = new Response(200, [], json_encode(['token' => 'fresh-token', 'code' => 200]));
+        $eventsError = RequestException::create(
+            new Request('POST', 'events'),
+            new Response(401, [], 'Unauthorized'),
+        );
+        $eventsSuccess = new Response(200, [], 'OK');
 
-    $client = makeClient([$loginResponse, $eventsError, $reLoginResponse, $eventsSuccess]);
-    $channel = new ServiceBusChannel(makeV2Config(), $client);
+        $client = makeClient([$loginResponse, $eventsError, $reLoginResponse, $eventsSuccess]);
+        $channel = new ServiceBusChannel(makeV2Config(), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
 
-    Log::shouldHaveReceived('info');
-});
+        Log::shouldHaveReceived('info');
+    },
+);
 
 // Test 6 (COVR-03): 403 retry success
-it('retries after 403 with fresh token', function () {
-    Log::spy();
+it(
+    'retries after 403 with fresh token',
+    function () {
+        Log::spy();
 
-    $loginResponse = new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200]));
-    $reLoginResponse = new Response(200, [], json_encode(['token' => 'fresh-token', 'code' => 200]));
-    $eventsError = RequestException::create(
-        new Request('POST', 'events'),
-        new Response(403, [], 'Forbidden'),
-    );
-    $eventsSuccess = new Response(200, [], 'OK');
+        $loginResponse = new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200]));
+        $reLoginResponse = new Response(200, [], json_encode(['token' => 'fresh-token', 'code' => 200]));
+        $eventsError = RequestException::create(
+            new Request('POST', 'events'),
+            new Response(403, [], 'Forbidden'),
+        );
+        $eventsSuccess = new Response(200, [], 'OK');
 
-    $client = makeClient([$loginResponse, $eventsError, $reLoginResponse, $eventsSuccess]);
-    $channel = new ServiceBusChannel(makeV2Config(), $client);
+        $client = makeClient([$loginResponse, $eventsError, $reLoginResponse, $eventsSuccess]);
+        $channel = new ServiceBusChannel(makeV2Config(), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
 
-    Log::shouldHaveReceived('info');
-});
+        Log::shouldHaveReceived('info');
+    },
+);
 
 // Test 7 (COVR-03): Exhausted retry throws authFailed
-it('throws authFailed after exhausted retry on double 401', function () {
-    Log::spy();
+it(
+    'throws authFailed after exhausted retry on double 401',
+    function () {
+        Log::spy();
 
-    $loginResponse = new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200]));
-    $reLoginResponse = new Response(200, [], json_encode(['token' => 'fresh-token', 'code' => 200]));
-    $eventsError1 = RequestException::create(
-        new Request('POST', 'events'),
-        new Response(401, [], 'Unauthorized'),
-    );
-    $eventsError2 = RequestException::create(
-        new Request('POST', 'events'),
-        new Response(401, [], 'Unauthorized'),
-    );
+        $loginResponse = new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200]));
+        $reLoginResponse = new Response(200, [], json_encode(['token' => 'fresh-token', 'code' => 200]));
+        $eventsError1 = RequestException::create(
+            new Request('POST', 'events'),
+            new Response(401, [], 'Unauthorized'),
+        );
+        $eventsError2 = RequestException::create(
+            new Request('POST', 'events'),
+            new Response(401, [], 'Unauthorized'),
+        );
 
-    $client = makeClient([$loginResponse, $eventsError1, $reLoginResponse, $eventsError2]);
-    $channel = new ServiceBusChannel(makeV2Config(), $client);
+        $client = makeClient([$loginResponse, $eventsError1, $reLoginResponse, $eventsError2]);
+        $channel = new ServiceBusChannel(makeV2Config(), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-})->throws(CouldNotSendNotification::class, 'auth token');
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+)->throws(CouldNotSendNotification::class, 'auth token');
 
 // Test 8 (COVR-04): Non-auth request exception throws requestFailed
-it('throws requestFailed on non-auth request exception', function () {
-    Log::spy();
+it(
+    'throws requestFailed on non-auth request exception',
+    function () {
+        Log::spy();
 
-    $loginResponse = new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200]));
-    $eventsError = RequestException::create(
-        new Request('POST', 'events'),
-        new Response(500, [], 'Server Error'),
-    );
+        $loginResponse = new Response(200, [], json_encode(['token' => 'test-token', 'code' => 200]));
+        $eventsError = RequestException::create(
+            new Request('POST', 'events'),
+            new Response(500, [], 'Server Error'),
+        );
 
-    $client = makeClient([$loginResponse, $eventsError]);
-    $channel = new ServiceBusChannel(makeV2Config(), $client);
+        $client = makeClient([$loginResponse, $eventsError]);
+        $channel = new ServiceBusChannel(makeV2Config(), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-})->throws(CouldNotSendNotification::class, 'logging the event');
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+)->throws(CouldNotSendNotification::class, 'logging the event');
 
 // Test 9 (COVR-05): Login returns non-200 body code throws loginFailed
-it('throws loginFailed when login returns non-200 body code', function () {
-    Log::spy();
+it(
+    'throws loginFailed when login returns non-200 body code',
+    function () {
+        Log::spy();
 
-    $loginResponse = new Response(200, [], json_encode(['code' => 500, 'message' => 'Invalid credentials']));
+        $loginResponse = new Response(200, [], json_encode(['code' => 500, 'message' => 'Invalid credentials']));
 
-    $client = makeClient([$loginResponse]);
-    $channel = new ServiceBusChannel(makeV2Config(), $client);
+        $client = makeClient([$loginResponse]);
+        $channel = new ServiceBusChannel(makeV2Config(), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-})->throws(CouldNotSendNotification::class, 'logging in');
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+)->throws(CouldNotSendNotification::class, 'logging in');
 
 // Test 10 (COVR-05): Login network error throws requestFailed
-it('throws requestFailed when login request fails with network error', function () {
-    Log::spy();
+it(
+    'throws requestFailed when login request fails with network error',
+    function () {
+        Log::spy();
 
-    $loginError = new RequestException('Connection timed out', new Request('POST', 'login'));
+        $loginError = new RequestException('Connection timed out', new Request('POST', 'login'));
 
-    $client = makeClient([$loginError]);
-    $channel = new ServiceBusChannel(makeV2Config(), $client);
+        $client = makeClient([$loginError]);
+        $channel = new ServiceBusChannel(makeV2Config(), $client);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-})->throws(CouldNotSendNotification::class, 'logging the event');
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+)->throws(CouldNotSendNotification::class, 'logging the event');

--- a/tests/ServiceBusEventTest.php
+++ b/tests/ServiceBusEventTest.php
@@ -29,124 +29,308 @@ function config_v2(): array
     ];
 }
 
-test('should create service bus event instance', function () {
-    $serviceBus = new ServiceBusEvent('test', config_v2());
+test(
+    'should create service bus event instance',
+    function () {
+        $serviceBus = new ServiceBusEvent('test', config_v2());
 
-    expect($serviceBus->getEventType())->toEqual('test');
-});
+        expect($serviceBus->getEventType())->toEqual('test');
+    },
+);
 
-test('should create service bus event instance via static call', function () {
-    $serviceBus = ServiceBusEvent::create('test', config_v2());
+test(
+    'should create service bus event instance via static call',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v2());
 
-    expect($serviceBus->getEventType())->toEqual('test');
-});
+        expect($serviceBus->getEventType())->toEqual('test');
+    },
+);
 
-test('should throw invalid config exception', function () {
-    ServiceBusEvent::create('test')
-        ->withAction('test', uniqid())
-        ->withCulture('en')
-        ->withReference(uniqid())
-        ->withRoute('api')
-        ->createdAt(Carbon::now())
-        ->withResources('resources', ['data']);
-})->throws(InvalidConfigException::class);
+test(
+    'should throw invalid config exception',
+    function () {
+        ServiceBusEvent::create('test')
+            ->withAction('test', uniqid())
+            ->withCulture('en')
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withResources('resources', ['data']);
+    },
+)->throws(InvalidConfigException::class);
 
-test('should allocate attributes to service bus object', function () {
-    $resource = [
-        'user' => 'John Doe',
-        'email' => 'john@doe.com',
-        'phone' => '0123456789',
-    ];
-
-    $serviceBus = ServiceBusEvent::create('test', config_v2())
-        ->withAction('other', uniqid())
-        ->withCulture('en')
-        ->withReference(uniqid())
-        ->withRoute('api')
-        ->createdAt(Carbon::now())
-        ->withResources('resource', $resource);
-
-    $serviceBusData = $serviceBus->getParams();
-
-    expect($serviceBusData)->not->toBeEmpty();
-    expect($serviceBusData)->toHaveKey('events');
-    expect($serviceBusData)->toHaveKey('payload');
-    expect($serviceBusData['payload'])->toHaveKey('resource');
-    expect($serviceBusData['events'])->toContain('test');
-
-    expect($serviceBusData['payload']['resource'])->toEqual($resource);
-});
-
-test('should allocate attributes to service bus object with payload', function () {
-    $payload = [
-        'object' => [
+test(
+    'should allocate attributes to service bus object',
+    function () {
+        $resource = [
             'user' => 'John Doe',
             'email' => 'john@doe.com',
             'phone' => '0123456789',
-        ],
-    ];
+        ];
 
-    $serviceBus = ServiceBusEvent::create('test', config_v2())
-        ->withAction('other', uniqid())
-        ->withCulture('en')
-        ->withReference(uniqid())
-        ->withRoute('api')
-        ->createdAt(Carbon::now())
-        ->withPayload($payload);
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withAction('other', uniqid())
+            ->withCulture('en')
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withResources('resource', $resource);
 
-    $serviceBusData = $serviceBus->getParams();
+        $serviceBusData = $serviceBus->getParams();
 
-    expect($serviceBusData)->not->toBeEmpty();
-    expect($serviceBusData)->toHaveKey('events');
-    expect($serviceBusData)->toHaveKey('payload');
-    expect($serviceBusData['events'])->toContain('test');
+        expect($serviceBusData)->not->toBeEmpty();
+        expect($serviceBusData)->toHaveKey('events');
+        expect($serviceBusData)->toHaveKey('payload');
+        expect($serviceBusData['payload'])->toHaveKey('resource');
+        expect($serviceBusData['events'])->toContain('test');
 
-    expect($serviceBusData['payload'])->toEqual($payload);
-});
+        expect($serviceBusData['payload']['resource'])->toEqual($resource);
+    },
+);
 
-test('should return correct event for specific version', function () {
-    $serviceBusVersion1 = ServiceBusEvent::create('test', config_v1())
-        ->withAction('other', uniqid())
-        ->withCulture('en')
-        ->withReference(uniqid())
-        ->withRoute('api')
-        ->withPayload([
-            'listing' => [],
-        ])
-        ->createdAt(Carbon::now());
+test(
+    'should allocate attributes to service bus object with payload',
+    function () {
+        $payload = [
+            'object' => [
+                'user' => 'John Doe',
+                'email' => 'john@doe.com',
+                'phone' => '0123456789',
+            ],
+        ];
 
-    $serviceBusVersion2 = ServiceBusEvent::create('test', config_v2())
-        ->withReference(uniqid())
-        ->withRoute('api')
-        ->withPayload([
-            'listing' => [],
-        ])
-        ->createdAt(Carbon::now());
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withAction('other', uniqid())
+            ->withCulture('en')
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload($payload);
 
-    $serviceBusDataVersion1 = $serviceBusVersion1->getParams();
-    $serviceBusDataVersion2 = $serviceBusVersion2->getParams();
+        $serviceBusData = $serviceBus->getParams();
 
-    expect($serviceBusDataVersion1)->not->toBeEmpty();
-    expect($serviceBusDataVersion2)->not->toBeEmpty();
+        expect($serviceBusData)->not->toBeEmpty();
+        expect($serviceBusData)->toHaveKey('events');
+        expect($serviceBusData)->toHaveKey('payload');
+        expect($serviceBusData['events'])->toContain('test');
 
-    expect($serviceBusDataVersion1)->toHaveKey('events');
-    expect($serviceBusDataVersion1)->toHaveKey('payload');
-    expect($serviceBusDataVersion1)->toHaveKey('from');
-    expect($serviceBusDataVersion1)->toHaveKey('venture_config_id');
-    expect($serviceBusDataVersion1)->toHaveKey('venture_reference');
-    expect($serviceBusDataVersion1)->toHaveKey('reference');
+        expect($serviceBusData['payload'])->toEqual($payload);
+    },
+);
 
-    expect($serviceBusDataVersion2)->toHaveKey('from');
-    expect($serviceBusDataVersion2)->toHaveKey('events');
-    expect($serviceBusDataVersion2)->toHaveKey('payload');
-    expect($serviceBusDataVersion2)->toHaveKey('reference');
+test(
+    'should return correct event for specific version',
+    function () {
+        $serviceBusVersion1 = ServiceBusEvent::create('test', config_v1())
+            ->withAction('other', uniqid())
+            ->withCulture('en')
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->withPayload(
+                [
+                    'listing' => [],
+                ],
+            )
+            ->createdAt(Carbon::now());
 
-    expect($serviceBusDataVersion1['venture_config_id'])->not->toBeEmpty();
-    expect($serviceBusDataVersion1['venture_reference'])->not->toBeEmpty();
+        $serviceBusVersion2 = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->withPayload(
+                [
+                    'listing' => [],
+                ],
+            )
+            ->createdAt(Carbon::now());
 
-    expect($serviceBusDataVersion2['from'])->not->toBeEmpty();
-    expect($serviceBusDataVersion2['reference'])->not->toBeEmpty();
+        $serviceBusDataVersion1 = $serviceBusVersion1->getParams();
+        $serviceBusDataVersion2 = $serviceBusVersion2->getParams();
 
-    expect($serviceBusDataVersion1['events'])->toContain('test');
-    expect($serviceBusDataVersion2['events'])->toContain('test');
-});
+        expect($serviceBusDataVersion1)->not->toBeEmpty();
+        expect($serviceBusDataVersion2)->not->toBeEmpty();
+
+        expect($serviceBusDataVersion1)->toHaveKey('events');
+        expect($serviceBusDataVersion1)->toHaveKey('payload');
+        expect($serviceBusDataVersion1)->toHaveKey('from');
+        expect($serviceBusDataVersion1)->toHaveKey('venture_config_id');
+        expect($serviceBusDataVersion1)->toHaveKey('venture_reference');
+        expect($serviceBusDataVersion1)->toHaveKey('reference');
+
+        expect($serviceBusDataVersion2)->toHaveKey('from');
+        expect($serviceBusDataVersion2)->toHaveKey('events');
+        expect($serviceBusDataVersion2)->toHaveKey('payload');
+        expect($serviceBusDataVersion2)->toHaveKey('reference');
+
+        expect($serviceBusDataVersion1['venture_config_id'])->not->toBeEmpty();
+        expect($serviceBusDataVersion1['venture_reference'])->not->toBeEmpty();
+
+        expect($serviceBusDataVersion2['from'])->not->toBeEmpty();
+        expect($serviceBusDataVersion2['reference'])->not->toBeEmpty();
+
+        expect($serviceBusDataVersion1['events'])->toContain('test');
+        expect($serviceBusDataVersion2['events'])->toContain('test');
+    },
+);
+
+test(
+    'v2 getParams includes debounce_key key',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload(
+                [
+                    'listing' => ['reference' => 'listing-123'],
+                ],
+            );
+
+        expect($serviceBus->getParams())->toHaveKey('debounce_key');
+    },
+);
+
+test(
+    'v1 getParams does not include debounce_key',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v1())
+            ->withAction('other', 'a-ref')
+            ->withCulture('en')
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload(
+                [
+                    'listing' => ['reference' => 'listing-123'],
+                ],
+            );
+
+        expect($serviceBus->getParams())->not->toHaveKey('debounce_key');
+    },
+);
+
+test(
+    'debounce_key is null when payload is empty',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload([]);
+
+        expect($serviceBus->getParams()['debounce_key'])->toBeNull();
+    },
+);
+
+test(
+    'getParams succeeds when payload was never set (no withPayload/withResource call)',
+    function () {
+        // Regression: getDebounceKey calls getPayload, which previously assumed non-null payload.
+        // An event built without withPayload/withResource must still serialize cleanly with
+        // a null debounce_key — not TypeError.
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now());
+
+        $params = $serviceBus->getParams();
+
+        expect($params)->toHaveKey('debounce_key');
+        expect($params['debounce_key'])->toBeNull();
+        expect($params)->toHaveKey('payload');
+        expect($params['payload'])->toEqual([]);
+    },
+);
+
+test(
+    'debounce_key joins all payload entity references with underscores',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload(
+                [
+                    'listing' => ['reference' => 'listing-abc'],
+                    'user' => ['reference' => 'user-xyz'],
+                ],
+            );
+
+        expect($serviceBus->getParams()['debounce_key'])
+            ->toEqual('listing=listing-abc_user=user-xyz');
+    },
+);
+
+test(
+    'debounce_key is null when any payload entity is missing its reference',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload(
+                [
+                    'listing' => ['reference' => 'listing-abc'],
+                    'user' => ['name' => 'no reference here'],
+                ],
+            );
+
+        expect($serviceBus->getParams()['debounce_key'])->toBeNull();
+    },
+);
+
+test(
+    'debounce_key handles a single-entity payload',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload(
+                [
+                    'listing' => ['reference' => 'only-one'],
+                ],
+            );
+
+        expect($serviceBus->getParams()['debounce_key'])
+            ->toEqual('listing=only-one');
+    },
+);
+
+test(
+    'debounce_key preserves payload key insertion order',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload(
+                [
+                    'user' => ['reference' => 'u-1'],
+                    'listing' => ['reference' => 'l-2'],
+                    'advertiser' => ['reference' => 'a-3'],
+                ],
+            );
+
+        expect($serviceBus->getParams()['debounce_key'])
+            ->toEqual('user=u-1_listing=l-2_advertiser=a-3');
+    },
+);
+
+test(
+    'debounce_key is null when an entity reference is an empty string (filter() drops falsy)',
+    function () {
+        $serviceBus = ServiceBusEvent::create('test', config_v2())
+            ->withReference(uniqid())
+            ->withRoute('api')
+            ->createdAt(Carbon::now())
+            ->withPayload(
+                [
+                    'listing' => ['reference' => 'listing-abc'],
+                    'user' => ['reference' => ''],
+                ],
+            );
+
+        expect($serviceBus->getParams()['debounce_key'])->toBeNull();
+    },
+);

--- a/tests/ServiceBusSQSChannelTest.php
+++ b/tests/ServiceBusSQSChannelTest.php
@@ -4,8 +4,11 @@ use Aws\CommandInterface;
 use Aws\Exception\AwsException;
 use Aws\Result;
 use Aws\Sqs\SqsClient;
+use Carbon\Carbon;
 use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Log;
+use Ringierimu\ServiceBusNotificationsChannel\ServiceBusEvent;
 use Ringierimu\ServiceBusNotificationsChannel\ServiceBusSQSChannel;
 use Ringierimu\ServiceBusNotificationsChannel\Tests\TestNotification;
 
@@ -13,19 +16,70 @@ use Ringierimu\ServiceBusNotificationsChannel\Tests\TestNotification;
 // the FIFO code path (MessageGroupId/MessageDeduplicationId).
 function makeSqsConfig(array $overrides = []): array
 {
-    return array_merge([
-        'enabled' => true,
-        'node_id' => '123456789',
-        'from' => 'test-node',
-        'version' => '2.0.0',
-        'dont_report' => [],
-        'sqs' => [
-            'region' => 'us-east-1',
-            'key' => 'fake-key',
-            'secret' => 'fake-secret',
-            'queue_url' => 'https://sqs.us-east-1.amazonaws.com/123/test-queue.fifo',
+    return array_merge(
+        [
+            'enabled' => true,
+            'node_id' => '123456789',
+            'from' => 'test-node',
+            'version' => '2.0.0',
+            'dont_report' => [],
+            'sqs' => [
+                'region' => 'us-east-1',
+                'key' => 'fake-key',
+                'secret' => 'fake-secret',
+                'queue_url' => 'https://sqs.us-east-1.amazonaws.com/123/test-queue.fifo',
+            ],
         ],
-    ], $overrides);
+        $overrides,
+    );
+}
+
+// Event 'from' resolves via the event's own config — services.service_bus from TestCase,
+// whose node_id is '123456789' and no explicit 'from'. So MessageGroupId always begins with this.
+const SQS_TEST_EVENT_FROM = '123456789';
+
+function makeKnownNotification(string $eventType, array $payload = []): Notification
+{
+    return new class ($eventType, $payload) extends Notification {
+        public function __construct(
+            public string $eventType,
+            public array $payload,
+        ) {
+        }
+
+        public function toServiceBus()
+        {
+            $event = ServiceBusEvent::create($this->eventType)
+                ->withRoute('api')
+                ->createdAt(Carbon::now());
+
+            if (!empty($this->payload)) {
+                $event->withPayload($this->payload);
+            }
+
+            return $event;
+        }
+    };
+}
+
+function mockSqsCapturingSendMessage(&$captured): SqsClient
+{
+    // Use andReturnUsing so the side-effect capture only fires when the expectation
+    // is actually fulfilled — Mockery::on closures get evaluated during matcher
+    // dispatch, which corrupts captures across multi-expectation mocks.
+    $sqsMock = Mockery::mock(SqsClient::class);
+    $sqsMock
+        ->shouldReceive('sendMessage')
+        ->once()
+        ->andReturnUsing(
+            function ($args) use (&$captured) {
+                $captured = $args;
+
+                return new Result(['MessageId' => 'test-msg-id']);
+            },
+        );
+
+    return $sqsMock;
 }
 
 function makeAwsCredentialError(string $code = 'ExpiredToken'): AwsException
@@ -37,149 +91,393 @@ function makeAwsCredentialError(string $code = 'ExpiredToken'): AwsException
     );
 }
 
-it('sends message to SQS successfully', function () {
-    Log::spy();
+it(
+    'sends message to SQS successfully',
+    function () {
+        Log::spy();
 
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->with(Mockery::on(function ($args) {
-            return isset($args['QueueUrl'])
-                && $args['QueueUrl'] === 'https://sqs.us-east-1.amazonaws.com/123/test-queue.fifo'
-                && isset($args['MessageBody'])
-                && json_decode($args['MessageBody'], true) !== null
-                && isset($args['MessageGroupId']);
-        }))
-        ->andReturn(new Result(['MessageId' => 'test-msg-id']));
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock
+            ->shouldReceive('sendMessage')
+            ->once()
+            ->with(
+                Mockery::on(
+                    function ($args) {
+                        return isset($args['QueueUrl'])
+                            && $args['QueueUrl'] === 'https://sqs.us-east-1.amazonaws.com/123/test-queue.fifo'
+                            && isset($args['MessageBody'])
+                            && json_decode($args['MessageBody'], true) !== null
+                            && isset($args['MessageGroupId']);
+                    },
+                ),
+            )
+            ->andReturn(new Result(['MessageId' => 'test-msg-id']));
 
-    $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-
-    Log::shouldHaveReceived('info')->once();
-});
-
-it('logs debug when disabled and event not in dont_report', function () {
-    Log::shouldReceive('debug')
-        ->once()
-        ->with(
-            Mockery::pattern('/test.*\[disabled\]/'),
-            Mockery::type('array'),
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification(
+                'ListingCreated',
+                [
+                    'listing' => ['reference' => 'L-1'],
+                ],
+            ),
         );
 
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldNotReceive('sendMessage');
+        Log::shouldHaveReceived('info')->once();
+    },
+);
 
-    $channel = new ServiceBusSQSChannel(
-        makeSqsConfig(['enabled' => false, 'dont_report' => []]),
-        $sqsMock,
-    );
+it(
+    'logs debug when disabled and event not in dont_report',
+    function () {
+        Log::shouldReceive('debug')
+            ->once()
+            ->with(
+                Mockery::pattern('/test.*\[disabled\]/'),
+                Mockery::type('array'),
+            );
 
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-});
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldNotReceive('sendMessage');
 
-it('suppresses log when disabled and event in dont_report', function () {
-    Log::shouldReceive('debug')->never();
-
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldNotReceive('sendMessage');
-
-    $channel = new ServiceBusSQSChannel(
-        makeSqsConfig(['enabled' => false, 'dont_report' => ['test']]),
-        $sqsMock,
-    );
-
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-});
-
-it('sets MessageGroupId and MessageDeduplicationId on FIFO queues', function () {
-    Log::spy();
-    $captured = null;
-
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->andReturnUsing(function ($args) use (&$captured) {
-            $captured = $args;
-
-            return new Result(['MessageId' => 'msg-1']);
-        });
-
-    $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-
-    expect($captured)->toHaveKey('MessageGroupId');
-    expect($captured['MessageGroupId'])->toEqual('123456789');
-    expect($captured)->toHaveKey('MessageDeduplicationId');
-    expect($captured['MessageDeduplicationId'])->toEqual(md5($captured['MessageBody']));
-});
-
-it('omits FIFO-only fields when the queue URL is not a .fifo queue', function () {
-    Log::spy();
-    $captured = null;
-
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->andReturnUsing(function ($args) use (&$captured) {
-            $captured = $args;
-
-            return new Result(['MessageId' => 'msg-1']);
-        });
-
-    $config = makeSqsConfig();
-    $config['sqs']['queue_url'] = 'https://sqs.us-east-1.amazonaws.com/123/standard-queue';
-
-    $channel = new ServiceBusSQSChannel($config, $sqsMock);
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-
-    expect($captured)->not->toHaveKey('MessageGroupId');
-    expect($captured)->not->toHaveKey('MessageDeduplicationId');
-    expect($captured['QueueUrl'])->toEqual('https://sqs.us-east-1.amazonaws.com/123/standard-queue');
-    expect(json_decode($captured['MessageBody'], true))->not->toBeNull();
-});
-
-it('retries once on AWS credential error and succeeds on the second attempt', function () {
-    Log::spy();
-
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->ordered()
-        ->andThrow(makeAwsCredentialError('ExpiredToken'));
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->ordered()
-        ->andReturn(new Result(['MessageId' => 'retry-msg-id']));
-
-    $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-
-    Log::shouldHaveReceived('warning')
-        ->once()
-        ->with(
-            Mockery::pattern('/ExpiredToken.*refreshing.*retrying/'),
-            Mockery::type('array'),
+        $channel = new ServiceBusSQSChannel(
+            makeSqsConfig(['enabled' => false, 'dont_report' => []]),
+            $sqsMock,
         );
-    Log::shouldHaveReceived('info')->once();
-});
 
-it('retries on each credential error code in the allowlist', function (string $code) {
-    Log::spy();
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+);
 
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->ordered()
-        ->andThrow(makeAwsCredentialError($code));
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->ordered()
-        ->andReturn(new Result(['MessageId' => 'ok']));
+it(
+    'suppresses log when disabled and event in dont_report',
+    function () {
+        Log::shouldReceive('debug')->never();
 
-    $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
-})->with([
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldNotReceive('sendMessage');
+
+        $channel = new ServiceBusSQSChannel(
+            makeSqsConfig(['enabled' => false, 'dont_report' => ['test']]),
+            $sqsMock,
+        );
+
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+);
+
+it(
+    'builds MessageGroupId from the primary-entity reference per event-type taxonomy',
+    function (string $eventType, array $payload, string $expectedAppend) {
+        Log::spy();
+        $captured = null;
+        $sqsMock = mockSqsCapturingSendMessage($captured);
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(new AnonymousNotifiable(), makeKnownNotification($eventType, $payload));
+
+        expect($captured['MessageGroupId'])
+            ->toEqual(SQS_TEST_EVENT_FROM . '_' . $expectedAppend);
+    },
+)->with(
+    [
+        // listing taxonomy → listing={reference}
+        'ListingCreated' => ['ListingCreated', ['listing' => ['reference' => 'L1']], 'listing=L1'],
+        'ListingUpdated' => ['ListingUpdated', ['listing' => ['reference' => 'L2']], 'listing=L2'],
+        'ListingDeleted' => ['ListingDeleted', ['listing' => ['reference' => 'L3']], 'listing=L3'],
+        'ListingLeadCreated' => ['ListingLeadCreated', ['listing' => ['reference' => 'L4']], 'listing=L4'],
+        'ListingPromoted' => ['ListingPromoted', ['listing' => ['reference' => 'L5']], 'listing=L5'],
+        'ListingProductsAdded' => ['ListingProductsAdded', ['listing' => ['reference' => 'L6']], 'listing=L6'],
+        'ListingProductsRemoved' => ['ListingProductsRemoved', ['listing' => ['reference' => 'L7']], 'listing=L7'],
+        'ListingShared' => ['ListingShared', ['listing' => ['reference' => 'L8']], 'listing=L8'],
+        'ListingFavouriteCreated' => ['ListingFavouriteCreated', ['listing' => ['reference' => 'L9']], 'listing=L9'],
+        'ListingFavouriteRemoved' => ['ListingFavouriteRemoved', ['listing' => ['reference' => 'LA']], 'listing=LA'],
+
+        // topic taxonomy → topic={reference}
+        'TopicCreated' => ['TopicCreated', ['topic' => ['reference' => 'T1']], 'topic=T1'],
+        'TopicUpdated' => ['TopicUpdated', ['topic' => ['reference' => 'T2']], 'topic=T2'],
+        'TopicDeleted' => ['TopicDeleted', ['topic' => ['reference' => 'T3']], 'topic=T3'],
+
+        // alert taxonomy → user_alert={alert.user.reference}
+        'AlertCreated' => ['AlertCreated', ['alert' => ['user' => ['reference' => 'U-A1']]], 'user_alert=U-A1'],
+        'AlertUpdated' => ['AlertUpdated', ['alert' => ['user' => ['reference' => 'U-A2']]], 'user_alert=U-A2'],
+        'AlertDeleted' => ['AlertDeleted', ['alert' => ['user' => ['reference' => 'U-A3']]], 'user_alert=U-A3'],
+        'AlertSent' => ['AlertSent', ['alert' => ['user' => ['reference' => 'U-A4']]], 'user_alert=U-A4'],
+
+        // advertiser taxonomy → advertiser={reference}
+        'AdvertiserCreated' => ['AdvertiserCreated', ['advertiser' => ['reference' => 'AD1']], 'advertiser=AD1'],
+        'AdvertiserUpdated' => ['AdvertiserUpdated', ['advertiser' => ['reference' => 'AD2']], 'advertiser=AD2'],
+        'AdvertiserDeleted' => ['AdvertiserDeleted', ['advertiser' => ['reference' => 'AD3']], 'advertiser=AD3'],
+        'AdvertiserProductsAdded' => ['AdvertiserProductsAdded', ['advertiser' => ['reference' => 'AD4']], 'advertiser=AD4'],
+        'AdvertiserProductsRemoved' => ['AdvertiserProductsRemoved', ['advertiser' => ['reference' => 'AD5']], 'advertiser=AD5'],
+        'AdvertiserLeadCreated' => ['AdvertiserLeadCreated', ['advertiser' => ['reference' => 'AD6']], 'advertiser=AD6'],
+
+        // user taxonomy → user={reference}
+        'UserCreated' => ['UserCreated', ['user' => ['reference' => 'U1']], 'user=U1'],
+        'UserUpdated' => ['UserUpdated', ['user' => ['reference' => 'U2']], 'user=U2'],
+        'UserDeleted' => ['UserDeleted', ['user' => ['reference' => 'U3']], 'user=U3'],
+        'UserLogin' => ['UserLogin', ['user' => ['reference' => 'U4']], 'user=U4'],
+        'UserLogout' => ['UserLogout', ['user' => ['reference' => 'U5']], 'user=U5'],
+        'UserPasswordRequest' => ['UserPasswordRequest', ['user' => ['reference' => 'U6']], 'user=U6'],
+        'UserPasswordReset' => ['UserPasswordReset', ['user' => ['reference' => 'U7']], 'user=U7'],
+        'UserVerified' => ['UserVerified', ['user' => ['reference' => 'U8']], 'user=U8'],
+        'UserProductsAdded' => ['UserProductsAdded', ['user' => ['reference' => 'U9']], 'user=U9'],
+        'UserProductsRemoved' => ['UserProductsRemoved', ['user' => ['reference' => 'U10']], 'user=U10'],
+        'UserLeadCreated' => ['UserLeadCreated', ['user' => ['reference' => 'U11']], 'user=U11'],
+        'UserAnonymized' => ['UserAnonymized', ['user' => ['reference' => 'U12']], 'user=U12'],
+
+        // article taxonomy → article={reference}
+        'ArticleCreated' => ['ArticleCreated', ['article' => ['reference' => 'AR1']], 'article=AR1'],
+        'ArticleUpdated' => ['ArticleUpdated', ['article' => ['reference' => 'AR2']], 'article=AR2'],
+        'ArticleDeleted' => ['ArticleDeleted', ['article' => ['reference' => 'AR3']], 'article=AR3'],
+
+        // author taxonomy → author={reference}
+        'AuthorCreated' => ['AuthorCreated', ['author' => ['reference' => 'AU1']], 'author=AU1'],
+        'AuthorUpdated' => ['AuthorUpdated', ['author' => ['reference' => 'AU2']], 'author=AU2'],
+        'AuthorDeleted' => ['AuthorDeleted', ['author' => ['reference' => 'AU3']], 'author=AU3'],
+
+        // sport_event taxonomy → sport_event={reference}
+        'SportEventCreated' => ['SportEventCreated', ['sport_event' => ['reference' => 'SE1']], 'sport_event=SE1'],
+        'SportEventUpdated' => ['SportEventUpdated', ['sport_event' => ['reference' => 'SE2']], 'sport_event=SE2'],
+        'SportEventDeleted' => ['SportEventDeleted', ['sport_event' => ['reference' => 'SE3']], 'sport_event=SE3'],
+
+        // singleton groups (no reference appended, just a literal tag)
+        'SiteLeadCreated' => ['SiteLeadCreated', [], 'site_lead'],
+        'Callback' => ['Callback', [], 'callback'],
+        'Error' => ['Error', [], 'callback'],
+        'TestRunsDispatched' => ['TestRunsDispatched', [], 'test_run'],
+        'TestRunReceived' => ['TestRunReceived', [], 'test_run'],
+        'TestRunStarted' => ['TestRunStarted', [], 'test_run'],
+        'TestRunComplete' => ['TestRunComplete', [], 'test_run'],
+        'NewsletterSubscribed' => ['NewsletterSubscribed', [], 'newsletter'],
+        'NewsletterUnsubscribed' => ['NewsletterUnsubscribed', [], 'newsletter'],
+    ],
+);
+
+it(
+    'partitions different listing references into distinct MessageGroupIds (FIFO grouping)',
+    function () {
+        Log::spy();
+        $allArgs = [];
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock
+            ->shouldReceive('sendMessage')
+            ->twice()
+            ->andReturnUsing(
+                function ($args) use (&$allArgs) {
+                    $allArgs[] = $args;
+
+                    return new Result(['MessageId' => 'msg-' . count($allArgs)]);
+                },
+            );
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('ListingCreated', ['listing' => ['reference' => 'L-alpha']]),
+        );
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('ListingUpdated', ['listing' => ['reference' => 'L-beta']]),
+        );
+
+        expect($allArgs[0]['MessageGroupId'])->toEqual(SQS_TEST_EVENT_FROM . '_listing=L-alpha');
+        expect($allArgs[1]['MessageGroupId'])->toEqual(SQS_TEST_EVENT_FROM . '_listing=L-beta');
+        expect($allArgs[0]['MessageGroupId'])->not->toEqual($allArgs[1]['MessageGroupId']);
+    },
+);
+
+it(
+    'groups different event verbs for the same listing into the same MessageGroupId',
+    function () {
+        Log::spy();
+        $allArgs = [];
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock
+            ->shouldReceive('sendMessage')
+            ->twice()
+            ->andReturnUsing(
+                function ($args) use (&$allArgs) {
+                    $allArgs[] = $args;
+
+                    return new Result(['MessageId' => 'msg-' . count($allArgs)]);
+                },
+            );
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('ListingCreated', ['listing' => ['reference' => 'L-shared']]),
+        );
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('ListingPromoted', ['listing' => ['reference' => 'L-shared']]),
+        );
+
+        expect($allArgs[0]['MessageGroupId'])->toEqual($allArgs[1]['MessageGroupId']);
+        expect($allArgs[0]['MessageGroupId'])->toEqual(SQS_TEST_EVENT_FROM . '_listing=L-shared');
+    },
+);
+
+it(
+    'embeds debounce_key in the SQS MessageBody for v2 events',
+    function () {
+        Log::spy();
+        $captured = null;
+        $sqsMock = mockSqsCapturingSendMessage($captured);
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification(
+                'ListingCreated',
+                [
+                    'listing' => ['reference' => 'L-1'],
+                    'user' => ['reference' => 'U-1'],
+                ],
+            ),
+        );
+
+        $body = json_decode($captured['MessageBody'], true);
+        expect($body)->toHaveKey('debounce_key');
+        expect($body['debounce_key'])->toEqual('listing=L-1_user=U-1');
+    },
+);
+
+it(
+    'debounce_key is independent of MessageGroupId (debounce covers full ref combo, group covers primary entity only)',
+    function () {
+        Log::spy();
+        $captured = null;
+        $sqsMock = mockSqsCapturingSendMessage($captured);
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification(
+                'ListingCreated',
+                [
+                    'listing' => ['reference' => 'L-primary'],
+                    'user' => ['reference' => 'U-secondary'],
+                ],
+            ),
+        );
+
+        $body = json_decode($captured['MessageBody'], true);
+        expect($captured['MessageGroupId'])->toEqual(SQS_TEST_EVENT_FROM . '_listing=L-primary');
+        expect($body['debounce_key'])->toEqual('listing=L-primary_user=U-secondary');
+    },
+);
+
+it(
+    'falls back to bare from as MessageGroupId for an event type outside the taxonomy',
+    function () {
+        Log::spy();
+        $captured = null;
+        $sqsMock = mockSqsCapturingSendMessage($captured);
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('CompletelyUnknownEvent', []),
+        );
+
+        expect($captured['MessageGroupId'])->toEqual(SQS_TEST_EVENT_FROM);
+    },
+);
+
+it(
+    'sets MessageGroupId and MessageDeduplicationId on FIFO queues',
+    function () {
+        Log::spy();
+        $captured = null;
+        $sqsMock = mockSqsCapturingSendMessage($captured);
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('ListingCreated', ['listing' => ['reference' => 'L-fifo']]),
+        );
+
+        expect($captured)->toHaveKey('MessageGroupId');
+        expect($captured['MessageGroupId'])->toEqual(SQS_TEST_EVENT_FROM . '_listing=L-fifo');
+        expect($captured)->toHaveKey('MessageDeduplicationId');
+        expect($captured['MessageDeduplicationId'])->toEqual(md5($captured['MessageBody']));
+    },
+);
+
+it(
+    'omits FIFO-only fields when the queue URL is not a .fifo queue',
+    function () {
+        Log::spy();
+        $captured = null;
+        $sqsMock = mockSqsCapturingSendMessage($captured);
+
+        $config = makeSqsConfig();
+        $config['sqs']['queue_url'] = 'https://sqs.us-east-1.amazonaws.com/123/standard-queue';
+
+        $channel = new ServiceBusSQSChannel($config, $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('ListingCreated', ['listing' => ['reference' => 'L-std']]),
+        );
+
+        expect($captured)->not->toHaveKey('MessageGroupId');
+        expect($captured)->not->toHaveKey('MessageDeduplicationId');
+        expect($captured['QueueUrl'])->toEqual('https://sqs.us-east-1.amazonaws.com/123/standard-queue');
+        expect(json_decode($captured['MessageBody'], true))->not->toBeNull();
+    },
+);
+
+it(
+    'retries once on AWS credential error and succeeds on the second attempt',
+    function () {
+        Log::spy();
+
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldReceive('sendMessage')
+            ->once()
+            ->ordered()
+            ->andThrow(makeAwsCredentialError('ExpiredToken'));
+        $sqsMock->shouldReceive('sendMessage')
+            ->once()
+            ->ordered()
+            ->andReturn(new Result(['MessageId' => 'retry-msg-id']));
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->with(
+                Mockery::pattern('/ExpiredToken.*refreshing.*retrying/'),
+                Mockery::type('array'),
+            );
+        Log::shouldHaveReceived('info')->once();
+    },
+);
+
+it(
+    'retries on each credential error code in the allowlist',
+    function (string $code) {
+        Log::spy();
+
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldReceive('sendMessage')
+            ->once()
+            ->ordered()
+            ->andThrow(makeAwsCredentialError($code));
+        $sqsMock->shouldReceive('sendMessage')
+            ->once()
+            ->ordered()
+            ->andReturn(new Result(['MessageId' => 'ok']));
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+)->with([
     'ExpiredToken',
     'ExpiredTokenException',
     'InvalidClientTokenId',
@@ -188,55 +486,161 @@ it('retries on each credential error code in the allowlist', function (string $c
     'TokenRefreshRequired',
 ]);
 
-it('throws the original AwsException after exhausting credential retries', function () {
-    Log::spy();
-    $credentialError = makeAwsCredentialError('ExpiredToken');
+it(
+    'throws the original AwsException after exhausting credential retries',
+    function () {
+        Log::spy();
+        $credentialError = makeAwsCredentialError('ExpiredToken');
 
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldReceive('sendMessage')
-        ->twice()
-        ->andThrow($credentialError);
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldReceive('sendMessage')
+            ->twice()
+            ->andThrow($credentialError);
 
-    $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
 
-    expect(fn () => $channel->send(new AnonymousNotifiable(), new TestNotification()))
-        ->toThrow(AwsException::class, 'AWS error: ExpiredToken');
-});
+        expect(fn () => $channel->send(new AnonymousNotifiable(), new TestNotification()))
+            ->toThrow(AwsException::class, 'AWS error: ExpiredToken');
+    },
+);
 
-it('does not retry on non-credential AWS errors', function () {
-    Log::spy();
-    $otherError = new AwsException(
-        'Throttled',
-        Mockery::mock(CommandInterface::class),
-        ['code' => 'ThrottlingException', 'message' => 'Rate exceeded'],
-    );
+it(
+    'does not retry on non-credential AWS errors',
+    function () {
+        Log::spy();
+        $otherError = new AwsException(
+            'Throttled',
+            Mockery::mock(CommandInterface::class),
+            ['code' => 'ThrottlingException', 'message' => 'Rate exceeded'],
+        );
 
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->andThrow($otherError);
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldReceive('sendMessage')
+            ->once()
+            ->andThrow($otherError);
 
-    $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
 
-    expect(fn () => $channel->send(new AnonymousNotifiable(), new TestNotification()))
-        ->toThrow(AwsException::class, 'Throttled');
+        expect(fn () => $channel->send(new AnonymousNotifiable(), new TestNotification()))
+            ->toThrow(AwsException::class, 'Throttled');
 
-    Log::shouldNotHaveReceived('warning');
-});
+        Log::shouldNotHaveReceived('warning');
+    },
+);
 
-it('does not log success message when event type is in dont_report', function () {
-    Log::spy();
+it(
+    'does not log success message when event type is in dont_report',
+    function () {
+        Log::spy();
 
-    $sqsMock = Mockery::mock(SqsClient::class);
-    $sqsMock->shouldReceive('sendMessage')
-        ->once()
-        ->andReturn(new Result(['MessageId' => 'silent']));
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldReceive('sendMessage')
+            ->once()
+            ->andReturn(new Result(['MessageId' => 'silent']));
 
-    $channel = new ServiceBusSQSChannel(
-        makeSqsConfig(['dont_report' => ['test']]),
-        $sqsMock,
-    );
-    $channel->send(new AnonymousNotifiable(), new TestNotification());
+        $channel = new ServiceBusSQSChannel(
+            makeSqsConfig(['dont_report' => ['test']]),
+            $sqsMock,
+        );
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
 
-    Log::shouldNotHaveReceived('info');
-});
+        Log::shouldNotHaveReceived('info');
+    },
+);
+
+it(
+    'treats missing enabled key as disabled (Arr::get returns null, null == false)',
+    function () {
+        Log::shouldReceive('debug')->once();
+
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldNotReceive('sendMessage');
+
+        $config = makeSqsConfig();
+        unset($config['enabled']);
+
+        $channel = new ServiceBusSQSChannel($config, $sqsMock);
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+);
+
+it(
+    'treats falsy enabled values as disabled (null, false, 0, "")',
+    function (mixed $value) {
+        Log::shouldReceive('debug')->once();
+
+        $sqsMock = Mockery::mock(SqsClient::class);
+        $sqsMock->shouldNotReceive('sendMessage');
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(['enabled' => $value]), $sqsMock);
+        $channel->send(new AnonymousNotifiable(), new TestNotification());
+    },
+)->with(
+    [
+        'null' => [null],
+        'false' => [false],
+        'zero int' => [0],
+        'empty string' => [''],
+    ],
+);
+
+it(
+    'treats truthy enabled values as enabled (true, 1, non-empty string)',
+    function (mixed $value) {
+        Log::spy();
+        $captured = null;
+        $sqsMock = mockSqsCapturingSendMessage($captured);
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(['enabled' => $value]), $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('ListingCreated', ['listing' => ['reference' => 'L-1']]),
+        );
+
+        expect($captured)->not->toBeNull();
+    },
+)->with(
+    [
+        'true' => [true],
+        'one int' => [1],
+        'string' => ['true'],
+    ],
+);
+
+it(
+    'ListingUpdated with prop-shaped payload produces non-empty MessageGroupId and debounce_key',
+    function () {
+        Log::spy();
+        $captured = null;
+        $sqsMock = mockSqsCapturingSendMessage($captured);
+
+        // Mirrors prop's AbstractListingNotification::getPayload() output —
+        // a single 'listing' entry whose inner array has a top-level 'reference'
+        // (set in ListingResource::toArray as (string) $listing->id).
+        $payload = [
+            'listing' => [
+                'reference' => '12345',
+                'advertiser_reference' => '99',
+                'user_reference' => '7',
+                'status' => 'online',
+                'title' => [
+                    ['culture' => 'en_GB', 'value' => 'Test Listing'],
+                ],
+            ],
+        ];
+
+        $channel = new ServiceBusSQSChannel(makeSqsConfig(), $sqsMock);
+        $channel->send(
+            new AnonymousNotifiable(),
+            makeKnownNotification('ListingUpdated', $payload),
+        );
+
+        $body = json_decode($captured['MessageBody'], true);
+
+        expect($captured['MessageGroupId'])->toEqual(SQS_TEST_EVENT_FROM . '_listing=12345');
+        expect($body)->toHaveKey('debounce_key');
+        expect($body['debounce_key'])->toEqual('listing=12345');
+        expect($body['debounce_key'])->not->toBeEmpty();
+        expect($body['debounce_key'])->not->toBeNull();
+    },
+);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,16 +15,22 @@ class TestCase extends OrchestraTestCase
 
     protected function defineEnvironment($app)
     {
-        tap($app['config'], function (Repository $config) {
-            $config->set('cache.default', 'array');
-            $config->set('services.service_bus', [
-                'enabled' => true,
-                'node_id' => '123456789',
-                'username' => 'username',
-                'password' => 'password',
-                'version' => '2.0.0',
-                'endpoint' => 'https://bus.staging.ritdu.tech/v1/',
-            ]);
-        });
+        tap(
+            $app['config'],
+            function (Repository $config) {
+                $config->set('cache.default', 'array');
+                $config->set(
+                    'services.service_bus',
+                    [
+                        'enabled' => true,
+                        'node_id' => '123456789',
+                        'username' => 'username',
+                        'password' => 'password',
+                        'version' => '2.0.0',
+                        'endpoint' => 'https://bus.staging.ritdu.tech/v1/',
+                    ],
+                );
+            },
+        );
     }
 }


### PR DESCRIPTION
## Stacked on #47

This PR is **stacked on top of [#47](https://github.com/RingierIMU/service-bus-notifications-channel/pull/47)** (FIFO/standard queue support + bounded credential retry). The base branch is `jobs-11813-laravel-12-upgrade` so the diff shows only this PR's delta — merge #47 first, then this.

## Summary

Three additions, bundled:

### 1. Per-entity `MessageGroupId` (SQS FIFO grouping)

The per-entity routing taxonomy from this PR slots **inside** #47's `isFifoQueue()` branch, so it only fires for `.fifo` queues. `ServiceBusSQSChannel::buildSqsPayload()` appends an event-type-specific tag to `$params['from']` — e.g. `ListingCreated` → `{from}_listing={listing.reference}` — so SQS FIFO ordering partitions by the **primary entity** of each event. Every event for the same listing (created, updated, promoted, deleted) shares a group ID and stays in order. The `match` expression enumerates the full taxonomy with `default => null`: unknown event types silently fall through to bare `$from`. Standard queues (URLs without `.fifo`) skip `MessageGroupId` entirely — that's #47's behaviour, unchanged.

### 2. `debounce_key` per full reference combination (v2 event params)

`ServiceBusEvent::getParams()` emits `debounce_key`, joining every payload entity's `reference` into `key1=ref1_key2=ref2_...`. Captures the **full reference combination** for application-layer deduplication, independent of SQS's content-based dedup (which #47 already enables via `MessageDeduplicationId = md5(body)`). Returns `null` if any payload entity is missing a reference (or has a falsy one — `collect()->filter()` drops empty strings, `0`, etc.).

### 3. Laravel 13 support + dependency cleanup

- **Add Laravel 13.x** (released 2026-03-17 — zero breaking changes from 12.x).
- **CI matrix** extended with the L13/testbench `^11.0` row alongside existing L11/L12.
- **GitHub Actions bumped**: `actions/checkout@v4` → `@v6`, `actions/cache@v4` → `@v5`.
- **Legacy constraints dropped** for deps where the older major is no longer needed: `nunomaduro/collision ^7.0`, `tightenco/tlint ^8`, `guzzlehttp/psr7 ^1`.
- **Docs updated**: README badge, Supported Versions table, Requirements; CHANGELOG `[Unreleased]`.

## Conceptual model (MessageGroupId vs debounce_key vs MessageDeduplicationId)

| Field | Set by | Scope | Uniqueness | Purpose |
|---|---|---|---|---|
| `MessageGroupId` | This PR | Primary entity (FIFO only) | One per `(from, primary_entity_ref)` tuple | FIFO ordering within a partition |
| `MessageDeduplicationId` | #47 | Whole message body | `md5(body)` | SQS-side dedup independent of `ContentBasedDeduplication` setting |
| `debounce_key` | This PR | Every payload entity | One per full reference combination | Downstream application-layer dedupe |

A single listing being created, updated, then promoted will share a `MessageGroupId` (preserving order) but may have different `debounce_key`s if e.g. the user reference in payload differs.

## Other code-level changes

- **Stop double-resolving the event** in `ServiceBusSQSChannel::send()` — the previous code called `$notification->toServiceBus($notifiable)->getParams()` a second time after already having `$event = $notification->toServiceBus($notifiable)`. Now reuses the existing `$event`.
- **Null-safe `getPayload()`**: returns `[]` when `$this->payload` was never assigned, so `getDebounceKey()` (called unconditionally from `getParams()` in v2) doesn't throw `TypeError` for events built without `withPayload()`/`withResource()`.
- The `enabled` gate is unchanged from #47 (`Arr::get($config, 'enabled') == false`) — missing key / null / falsy values disable the channel; truthy values enable it.
- README's old "must be a FIFO queue" requirements section was removed (no longer true after #47); the FIFO-vs-standard guidance from #47 was extended with the per-entity routing detail.

## Rebase note

This PR was rebased onto #47 via a single squash commit (the per-commit rebase produced cascading conflicts where #47's `send()` refactor and this PR's per-entity routing both touched the same dispatch path). The original 7-commit `MessageGroupId` branch is preserved locally as `MessageGroupId-original-backup` for reference.

## Test plan

- [x] `./vendor/bin/pest` on Laravel 13.9.0 + testbench 11.1.0 — **107 passed (242 assertions)** on the merged state
- [x] Full taxonomy coverage: every event type in the `match` arm tested via dataset (52 cases across Listing×10, Topic×3, Alert×4, Advertiser×6, User×12, Article×3, Author×3, SportEvent×3, plus no-reference singletons: SiteLead, Callback/Error, TestRun×4, Newsletter×2)
- [x] FIFO grouping: distinct listing refs → distinct `MessageGroupId`s; same listing across different verbs → same `MessageGroupId`
- [x] FIFO `MessageDeduplicationId` is `md5(body)` (carried from #47)
- [x] Standard-queue path: `MessageGroupId` and `MessageDeduplicationId` both omitted (carried from #47)
- [x] `debounce_key` × `MessageGroupId` independence verified
- [x] Unknown event type → falls back to bare `from` (pins `default => null` semantics)
- [x] Credential retry path still green: 6-code allowlist retries once, exhausted retries throw, non-credential errors don't retry (carried from #47)
- [x] `enabled` semantics: missing key → disabled; falsy values (null, false, 0, "") → disabled; truthy values (true, 1, non-empty string) → enabled
- [x] Null-payload regression: `getParams()` returns clean structure when `withPayload()` was never called
- [x] Prop-shaped `ListingUpdated` regression: payload mirroring `AbstractListingNotification::getPayload()` produces non-empty `MessageGroupId` and `debounce_key`
- [ ] CI green across the new L11/L12/L13 × PHP 8.3/8.4 × prefer-lowest/prefer-stable matrix

## Notes for reviewers

- `match` with `default => null` means new event types added to the taxonomy will *not* fail loudly — they'll silently group by bare `from`. If you want strictness instead, drop the `default` arm.
- Legacy major drops (`collision ^7`, `tlint ^8`, `psr7 ^1`) are deliberate per the "latest major" intent. If any downstream pin requires them, they can be added back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)